### PR TITLE
Update Confluence.Kafka to 1.1.0

### DIFF
--- a/Akka.Streams.Kafka.sln
+++ b/Akka.Streams.Kafka.sln
@@ -18,6 +18,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.editorconfig = .editorconfig
 		docker-compose.yml = docker-compose.yml
 		README.md = README.md
+		src\common.props = src\common.props
 	EndProjectSection
 EndProject
 Global

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ akka.kafka.producer {
 ```
 
 ### Producer as a Sink
-`KafkaProducer.PlainSink` is the easiest way to publish messages. The sink consumes `Message` elements which contains a topic name to which the record is being sent, an optional partition number, and an optional key and value.
+`KafkaProducer.PlainSink` is the easiest way to publish messages. The sink consumes `MessageAndMeta` elements which contains a topic name to which the record is being sent, an optional partition number, and an optional key and value.
 
 ```C#
 Source

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ akka.kafka.producer {
 Source
     .From(Enumerable.Range(1, 100))
     .Select(c => c.ToString())
-    .Select(elem => new MessageAndMeta<Null, string> { Topic = "topic1", Message = new MessageAndMeta<Null, string> { Value = elem } })
+    .Select(elem => new MessageAndMeta<Null, string> { Topic = "topic1", Message = new Message<Null, string> { Value = elem } })
     .RunWith(KafkaProducer.PlainSink(producerSettings), materializer);
 ```
 The materialized value of the sink is a `Task` which is completed with result when the stream completes or with exception if an error occurs.
@@ -59,7 +59,7 @@ Sometimes there is a need for publishing messages in the middle of the stream pr
 Source
     .From(Enumerable.Range(1, 100))
     .Select(c => c.ToString())
-    .Select(elem => new MessageAndMeta<Null, string> { Topic = "topic1", Message = new MessageAndMeta<Null, string> { Value = elem } })
+    .Select(elem => new MessageAndMeta<Null, string> { Topic = "topic1", Message = new Message<Null, string> { Value = elem } })
     .Via(KafkaProducer.PlainFlow(producerSettings))
     .Select(record =>
     {

--- a/README.md
+++ b/README.md
@@ -41,13 +41,13 @@ akka.kafka.producer {
 ```
 
 ### Producer as a Sink
-`KafkaProducer.PlainSink` is the easiest way to publish messages. The sink consumes `MessageAndMeta` elements which contains a topic name to which the record is being sent, an optional partition number, and an optional key and value.
+`KafkaProducer.PlainSink` is the easiest way to publish messages. The sink consumes `Message` elements which contains a topic name to which the record is being sent, an optional partition number, and an optional key and value.
 
 ```C#
 Source
     .From(Enumerable.Range(1, 100))
     .Select(c => c.ToString())
-    .Select(elem => new MessageAndMeta<Null, string> { Topic = "topic1", Message = new Message<Null, string> { Value = elem } })
+    .Select(elem => new Message<Null, string> { Topic = "topic1", Message = new Message<Null, string> { Value = elem } })
     .RunWith(KafkaProducer.PlainSink(producerSettings), materializer);
 ```
 The materialized value of the sink is a `Task` which is completed with result when the stream completes or with exception if an error occurs.
@@ -59,7 +59,7 @@ Sometimes there is a need for publishing messages in the middle of the stream pr
 Source
     .From(Enumerable.Range(1, 100))
     .Select(c => c.ToString())
-    .Select(elem => new MessageAndMeta<Null, string> { Topic = "topic1", Message = new Message<Null, string> { Value = elem } })
+    .Select(elem => new Message<Null, string> { Topic = "topic1", Message = new Message<Null, string> { Value = elem } })
     .Via(KafkaProducer.PlainFlow(producerSettings))
     .Select(record =>
     {

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ akka.kafka.producer {
 Source
     .From(Enumerable.Range(1, 100))
     .Select(c => c.ToString())
-    .Select(elem => new Message<Null, string> { Topic = "topic1", Message = new Message<Null, string> { Value = elem } })
+    .Select(elem => new MessageAndMeta<Null, string> { Topic = "topic1", Message = new MessageAndMeta<Null, string> { Value = elem } })
     .RunWith(KafkaProducer.PlainSink(producerSettings), materializer);
 ```
 The materialized value of the sink is a `Task` which is completed with result when the stream completes or with exception if an error occurs.
@@ -59,7 +59,7 @@ Sometimes there is a need for publishing messages in the middle of the stream pr
 Source
     .From(Enumerable.Range(1, 100))
     .Select(c => c.ToString())
-    .Select(elem => new Message<Null, string> { Topic = "topic1", Message = new Message<Null, string> { Value = elem } })
+    .Select(elem => new MessageAndMeta<Null, string> { Topic = "topic1", Message = new MessageAndMeta<Null, string> { Value = elem } })
     .Via(KafkaProducer.PlainFlow(producerSettings))
     .Select(record =>
     {

--- a/examples/SimpleConsumer/Program.cs
+++ b/examples/SimpleConsumer/Program.cs
@@ -6,7 +6,7 @@ using Akka.Streams;
 using Akka.Streams.Kafka.Dsl;
 using Akka.Streams.Kafka.Settings;
 using Confluent.Kafka;
-using Confluent.Kafka.Serialization;
+using Config = Akka.Configuration.Config;
 
 namespace SimpleConsumer
 {
@@ -22,7 +22,7 @@ namespace SimpleConsumer
             var system = ActorSystem.Create("TestKafka", fallbackConfig);
             var materializer = system.Materializer();
 
-            var consumerSettings = ConsumerSettings<Null, string>.Create(system, null, new StringDeserializer(Encoding.UTF8))
+            var consumerSettings = ConsumerSettings<Null, string>.Create(system, null, null)
                 .WithBootstrapServers("localhost:29092")
                 .WithGroupId("group1");
 

--- a/examples/SimpleProducer/Program.cs
+++ b/examples/SimpleProducer/Program.cs
@@ -6,9 +6,10 @@ using Akka.Configuration;
 using Akka.Streams;
 using Akka.Streams.Dsl;
 using Akka.Streams.Kafka.Dsl;
+using Akka.Streams.Kafka.Messages;
 using Akka.Streams.Kafka.Settings;
 using Confluent.Kafka;
-using Confluent.Kafka.Serialization;
+using Config = Akka.Configuration.Config;
 
 namespace SimpleProducer
 {
@@ -24,9 +25,9 @@ namespace SimpleProducer
             var system = ActorSystem.Create("TestKafka", fallbackConfig);
             var materializer = system.Materializer();
 
-            var producerSettings = ProducerSettings<Null, string>.Create(system, null, new StringSerializer(Encoding.UTF8))
+            var producerSettings = ProducerSettings<Null, string>.Create(system, null, null)
                 .WithBootstrapServers("localhost:29092");
-
+            
             Source
                 .Cycle(() => Enumerable.Range(1, 100).GetEnumerator())
                 .Select(c => c.ToString())

--- a/src/Akka.Streams.Kafka.Tests/Integration/CommittableSourceIntegrationTests.cs
+++ b/src/Akka.Streams.Kafka.Tests/Integration/CommittableSourceIntegrationTests.cs
@@ -6,10 +6,10 @@ using System.Threading.Tasks;
 using Akka.Configuration;
 using Akka.Streams.Dsl;
 using Akka.Streams.Kafka.Dsl;
+using Akka.Streams.Kafka.Messages;
 using Akka.Streams.Kafka.Settings;
 using Akka.Streams.TestKit;
 using Confluent.Kafka;
-using Confluent.Kafka.Serialization;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -35,7 +35,7 @@ namespace Akka.Streams.Kafka.Tests.Integration
         private string CreateGroup(int number) => $"group-{number}-{Uuid}";
 
         private ProducerSettings<Null, string> ProducerSettings =>
-            ProducerSettings<Null, string>.Create(Sys, null, new StringSerializer(Encoding.UTF8))
+            ProducerSettings<Null, string>.Create(Sys, null, null)
                 .WithBootstrapServers(KafkaUrl);
 
         private async Task GivenInitializedTopic(string topic)
@@ -48,13 +48,13 @@ namespace Akka.Streams.Kafka.Tests.Integration
 
         private ConsumerSettings<Null, string> CreateConsumerSettings(string group)
         {
-            return ConsumerSettings<Null, string>.Create(Sys, null, new StringDeserializer(Encoding.UTF8))
+            return ConsumerSettings<Null, string>.Create(Sys, null, null)
                 .WithBootstrapServers(KafkaUrl)
                 .WithProperty("auto.offset.reset", "earliest")
                 .WithGroupId(group);
         }
 
-        [Fact(Skip = "Needs IMPL")]
+        [Fact/*(Skip = "Needs IMPL")*/]
         public async Task CommitableSource_consumes_messages_from_Producer_without_commits()
         {
             int elementsCount = 100;
@@ -83,7 +83,7 @@ namespace Akka.Streams.Kafka.Tests.Integration
             probe.Cancel();
         }
 
-        [Fact(Skip = "Needs IMPL")]
+        [Fact/*(Skip = "Needs IMPL")*/]
         public async Task CommitableSource_resume_from_commited_offset()
         {
             var topic1 = CreateTopic(1);

--- a/src/Akka.Streams.Kafka.Tests/Integration/CommittableSourceIntegrationTests.cs
+++ b/src/Akka.Streams.Kafka.Tests/Integration/CommittableSourceIntegrationTests.cs
@@ -54,7 +54,7 @@ namespace Akka.Streams.Kafka.Tests.Integration
                 .WithGroupId(group);
         }
 
-        [Fact/*(Skip = "Needs IMPL")*/]
+        [Fact]
         public async Task CommitableSource_consumes_messages_from_Producer_without_commits()
         {
             int elementsCount = 100;
@@ -83,7 +83,7 @@ namespace Akka.Streams.Kafka.Tests.Integration
             probe.Cancel();
         }
 
-        [Fact/*(Skip = "Needs IMPL")*/]
+        [Fact]
         public async Task CommitableSource_resume_from_commited_offset()
         {
             var topic1 = CreateTopic(1);

--- a/src/Akka.Streams.Kafka.Tests/Integration/PlainSinkIntegrationTests.cs
+++ b/src/Akka.Streams.Kafka.Tests/Integration/PlainSinkIntegrationTests.cs
@@ -54,7 +54,7 @@ namespace Akka.Streams.Kafka.Tests.Integration
                 .WithGroupId(group);
         }
 
-        [Fact/*(Skip = "Needs IMPL")*/]
+        [Fact]
         public async Task PlainSink_should_publish_100_elements_to_Kafka_producer()
         {
             var topic1 = CreateTopic(1);
@@ -97,7 +97,7 @@ namespace Akka.Streams.Kafka.Tests.Integration
             messagesReceived.Should().Be(100);
         }
 
-        [Fact(Skip = "Needs IMPL")]
+        [Fact]
         public async Task PlainSink_should_fail_stage_if_broker_unavailable()
         {
             var topic1 = CreateTopic(1);

--- a/src/Akka.Streams.Kafka.Tests/Integration/PlainSourceIntegrationTests.cs
+++ b/src/Akka.Streams.Kafka.Tests/Integration/PlainSourceIntegrationTests.cs
@@ -7,14 +7,15 @@ using System.Threading.Tasks;
 using Akka.Configuration;
 using Akka.Streams.Dsl;
 using Akka.Streams.Kafka.Dsl;
+using Akka.Streams.Kafka.Messages;
 using Akka.Streams.Kafka.Settings;
 using Akka.Streams.Supervision;
 using Akka.Streams.TestKit;
 using Confluent.Kafka;
-using Confluent.Kafka.Serialization;
 using FluentAssertions;
 using Xunit;
 using Xunit.Abstractions;
+using Config = Akka.Configuration.Config;
 
 namespace Akka.Streams.Kafka.Tests.Integration
 {
@@ -45,7 +46,7 @@ namespace Akka.Streams.Kafka.Tests.Integration
         private string CreateGroup(int number) => $"group-{number}-{Uuid}";
 
         private ProducerSettings<Null, string> ProducerSettings =>
-            ProducerSettings<Null, string>.Create(Sys, null, new StringSerializer(Encoding.UTF8))
+            ProducerSettings<Null, string>.Create(Sys, null, null)
                 .WithBootstrapServers(KafkaUrl);
 
         private async Task GivenInitializedTopic(string topic)
@@ -59,7 +60,7 @@ namespace Akka.Streams.Kafka.Tests.Integration
 
         private ConsumerSettings<Null, string> CreateConsumerSettings(string group)
         {
-            return ConsumerSettings<Null, string>.Create(Sys, null, new StringDeserializer(Encoding.UTF8))
+            return ConsumerSettings<Null, string>.Create(Sys, null, null)
                 .WithBootstrapServers(KafkaUrl)
                 .WithProperty("auto.offset.reset", "earliest")
                 .WithGroupId(group);
@@ -82,7 +83,7 @@ namespace Akka.Streams.Kafka.Tests.Integration
                 .RunWith(this.SinkProbe<string>(), _materializer);
         }
 
-        [Fact(Skip = "Needs IMPL")]
+        [Fact/*(Skip = "Needs IMPL")*/]
         public async Task PlainSource_consumes_messages_from_KafkaProducer_with_topicPartition_assignment()
         {
             int elementsCount = 100;
@@ -104,7 +105,7 @@ namespace Akka.Streams.Kafka.Tests.Integration
             probe.Cancel();
         }
 
-        [Fact(Skip = "Needs IMPL")]
+        [Fact/*(Skip = "Needs IMPL")*/]
         public async Task PlainSource_consumes_messages_from_KafkaProducer_with_topicPartitionOffset_assignment()
         {
             int elementsCount = 100;
@@ -149,7 +150,7 @@ namespace Akka.Streams.Kafka.Tests.Integration
             probe.Cancel();
         }
 
-        [Fact(Skip = "Needs IMPL")]
+        [Fact/*(Skip = "Needs IMPL")*/]
         public async Task PlainSource_should_fail_stage_if_broker_unavailable()
         {
             var topic1 = CreateTopic(1);
@@ -157,7 +158,7 @@ namespace Akka.Streams.Kafka.Tests.Integration
 
             await GivenInitializedTopic(topic1);
 
-            var config = ConsumerSettings<Null, string>.Create(Sys, null, new StringDeserializer(Encoding.UTF8))
+            var config = ConsumerSettings<Null, string>.Create(Sys, null, null)
                 .WithBootstrapServers("localhost:10092")
                 .WithGroupId(group1);
 
@@ -165,7 +166,7 @@ namespace Akka.Streams.Kafka.Tests.Integration
             probe.Request(1).ExpectError().Should().BeOfType<KafkaException>();
         }
 
-        [Fact(Skip = "Needs IMPL")]
+        [Fact/*(Skip = "Needs IMPL")*/]
         public async Task PlainSource_should_stop_on_deserialization_errors()
         {
             int elementsCount = 10;
@@ -174,7 +175,7 @@ namespace Akka.Streams.Kafka.Tests.Integration
 
             await Produce(topic1, Enumerable.Range(1, elementsCount), ProducerSettings);
 
-            var settings = ConsumerSettings<Null, int>.Create(Sys, null, new IntDeserializer())
+            var settings = ConsumerSettings<Null, int>.Create(Sys, null, Deserializers.Int32)
                 .WithBootstrapServers(KafkaUrl)
                 .WithProperty("auto.offset.reset", "earliest")
                 .WithGroupId(group1);
@@ -191,7 +192,7 @@ namespace Akka.Streams.Kafka.Tests.Integration
             probe.Cancel();
         }
 
-        [Fact(Skip = "Needs IMPL")]
+        [Fact/*(Skip = "Needs IMPL")*/]
         public async Task PlainSource_should_resume_on_deserialization_errors()
         {
             Directive Decider(Exception cause) => cause is SerializationException
@@ -204,7 +205,7 @@ namespace Akka.Streams.Kafka.Tests.Integration
 
             await Produce(topic1, Enumerable.Range(1, elementsCount), ProducerSettings);
 
-            var settings = ConsumerSettings<Null, int>.Create(Sys, null, new IntDeserializer())
+            var settings = ConsumerSettings<Null, int>.Create(Sys, null, Deserializers.Int32)
                 .WithBootstrapServers(KafkaUrl)
                 .WithProperty("auto.offset.reset", "earliest")
                 .WithGroupId(group1);

--- a/src/Akka.Streams.Kafka.Tests/Integration/PlainSourceIntegrationTests.cs
+++ b/src/Akka.Streams.Kafka.Tests/Integration/PlainSourceIntegrationTests.cs
@@ -83,7 +83,7 @@ namespace Akka.Streams.Kafka.Tests.Integration
                 .RunWith(this.SinkProbe<string>(), _materializer);
         }
 
-        [Fact/*(Skip = "Needs IMPL")*/]
+        [Fact]
         public async Task PlainSource_consumes_messages_from_KafkaProducer_with_topicPartition_assignment()
         {
             int elementsCount = 100;
@@ -105,7 +105,7 @@ namespace Akka.Streams.Kafka.Tests.Integration
             probe.Cancel();
         }
 
-        [Fact/*(Skip = "Needs IMPL")*/]
+        [Fact]
         public async Task PlainSource_consumes_messages_from_KafkaProducer_with_topicPartitionOffset_assignment()
         {
             int elementsCount = 100;
@@ -128,7 +128,7 @@ namespace Akka.Streams.Kafka.Tests.Integration
             probe.Cancel();
         }
 
-        [Fact(Skip = "Flaky")]
+        [Fact]
         public async Task PlainSource_consumes_messages_from_KafkaProducer_with_subscribe_to_topic()
         {
             int elementsCount = 100;
@@ -150,7 +150,7 @@ namespace Akka.Streams.Kafka.Tests.Integration
             probe.Cancel();
         }
 
-        [Fact/*(Skip = "Needs IMPL")*/]
+        [Fact]
         public async Task PlainSource_should_fail_stage_if_broker_unavailable()
         {
             var topic1 = CreateTopic(1);
@@ -166,7 +166,7 @@ namespace Akka.Streams.Kafka.Tests.Integration
             probe.Request(1).ExpectError().Should().BeOfType<KafkaException>();
         }
 
-        [Fact/*(Skip = "Needs IMPL")*/]
+        [Fact]
         public async Task PlainSource_should_stop_on_deserialization_errors()
         {
             int elementsCount = 10;
@@ -192,7 +192,7 @@ namespace Akka.Streams.Kafka.Tests.Integration
             probe.Cancel();
         }
 
-        [Fact/*(Skip = "Needs IMPL")*/]
+        [Fact]
         public async Task PlainSource_should_resume_on_deserialization_errors()
         {
             Directive Decider(Exception cause) => cause is SerializationException

--- a/src/Akka.Streams.Kafka/Akka.Streams.Kafka.csproj
+++ b/src/Akka.Streams.Kafka/Akka.Streams.Kafka.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\common.props" />
   <PropertyGroup>
     <AssemblyTitle>Akka.Streams.Kafka</AssemblyTitle>
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="Akka.Streams" Version="$(AkkaVersion)" />
-    <PackageReference Include="Confluent.Kafka" Version="1.0.0-experimental-2" />
+    <PackageReference Include="Confluent.Kafka" Version="1.1.0" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />
   </ItemGroup>
 

--- a/src/Akka.Streams.Kafka/Dsl/KafkaConsumer.cs
+++ b/src/Akka.Streams.Kafka/Dsl/KafkaConsumer.cs
@@ -22,7 +22,7 @@ namespace Akka.Streams.Kafka.Dsl
         /// possible, but when it is, it will make the consumption fully atomic and give "exactly once" semantics that are
         /// stronger than the "at-least once" semantics you get with Kafka's offset commit functionality.
         /// </summary>
-        public static Source<ConsumerRecord<K, V>, Task> PlainSource<K, V>(ConsumerSettings<K, V> settings, ISubscription subscription)
+        public static Source<ConsumeResult<K, V>, Task> PlainSource<K, V>(ConsumerSettings<K, V> settings, ISubscription subscription)
         {
             return Source.FromGraph(new KafkaSourceStage<K, V>(settings, subscription));
         }

--- a/src/Akka.Streams.Kafka/Dsl/KafkaProducer.cs
+++ b/src/Akka.Streams.Kafka/Dsl/KafkaProducer.cs
@@ -42,8 +42,7 @@ namespace Akka.Streams.Kafka.Dsl
         {
             var flow = Flow.FromGraph(new ProducerStage<TKey, TValue>(
                     settings,
-                    closeProducerOnStop: true,
-                    producerProvider : settings.CreateKafkaProducer))
+                    closeProducerOnStop: true))
                 .SelectAsync(settings.Parallelism, x => x);
 
             return string.IsNullOrEmpty(settings.DispatcherId) 
@@ -60,7 +59,7 @@ namespace Akka.Streams.Kafka.Dsl
             var flow = Flow.FromGraph(new ProducerStage<TKey, TValue>(
                     settings,
                     closeProducerOnStop: false,
-                    producerProvider: () => producer))
+                    customProducerProvider: () => producer))
                 .SelectAsync(settings.Parallelism, x => x);
 
             return string.IsNullOrEmpty(settings.DispatcherId)

--- a/src/Akka.Streams.Kafka/Messages/CommittableMessage.cs
+++ b/src/Akka.Streams.Kafka/Messages/CommittableMessage.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Akka.Streams.Kafka.Dsl;
 using Confluent.Kafka;
 
@@ -10,13 +11,13 @@ namespace Akka.Streams.Kafka.Messages
     /// </summary>
     public sealed class CommittableMessage<K, V>
     {
-        public CommittableMessage(ConsumerRecord<K, V> record, CommitableOffset commitableOffset)
+        public CommittableMessage(ConsumeResult<K, V> record, CommitableOffset commitableOffset)
         {
             Record = record;
             CommitableOffset = commitableOffset;
         }
 
-        public ConsumerRecord<K, V> Record { get; }
+        public ConsumeResult<K, V> Record { get; }
 
         public CommitableOffset CommitableOffset { get; }
     }
@@ -31,9 +32,9 @@ namespace Akka.Streams.Kafka.Messages
     /// </summary>
     public class CommitableOffset
     {
-        private readonly Func<CommittedOffsets> _task;
+        private readonly Func<List<TopicPartitionOffset>> _task;
 
-        public CommitableOffset(Func<CommittedOffsets> task, PartitionOffset offset)
+        public CommitableOffset(Func<List<TopicPartitionOffset>> task, PartitionOffset offset)
         {
             _task = task;
             Offset = offset;
@@ -41,7 +42,7 @@ namespace Akka.Streams.Kafka.Messages
 
         public PartitionOffset Offset { get; }
 
-        public CommittedOffsets Commit()
+        public List<TopicPartitionOffset> Commit()
         {
             return _task();
         }

--- a/src/Akka.Streams.Kafka/Messages/MessageAndMeta.cs
+++ b/src/Akka.Streams.Kafka/Messages/MessageAndMeta.cs
@@ -1,0 +1,16 @@
+using Confluent.Kafka;
+
+namespace Akka.Streams.Kafka.Messages
+{
+    /// <summary>
+    /// Container for storing message and topic/parition info
+    /// </summary>
+    /// <typeparam name="K">Type of key</typeparam>
+    /// <typeparam name="V">Type of value</typeparam>
+    public class MessageAndMeta<K, V>
+    {
+        public Message<K, V> Message { get; set; }
+        public string Topic { get; set; }
+        public TopicPartition TopicPartition { get; set; }
+    }
+}

--- a/src/Akka.Streams.Kafka/Settings/KafkaExtensions.cs
+++ b/src/Akka.Streams.Kafka/Settings/KafkaExtensions.cs
@@ -24,6 +24,11 @@ namespace Akka.Streams.Kafka.Settings
             return false;
         }
 
+        public static bool IsLocalValueSerializationError(Error error)
+        {
+            return error.Code == ErrorCode.Local_ValueSerialization || error.Code == ErrorCode.Local_ValueDeserialization;
+        }
+
         public static bool IsLocalErrorRetriable(Error error)
         {
             switch (error.Code)

--- a/src/Akka.Streams.Kafka/Settings/ProducerSettings.cs
+++ b/src/Akka.Streams.Kafka/Settings/ProducerSettings.cs
@@ -2,14 +2,15 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using Akka.Actor;
-using Akka.Configuration;
-using Confluent.Kafka.Serialization;
+using Confluent.Kafka;
+using Config = Akka.Configuration.Config;
 
 namespace Akka.Streams.Kafka.Settings
 {
     public sealed class ProducerSettings<TKey, TValue>
     {
-        public ProducerSettings(ISerializer<TKey> keySerializer, ISerializer<TValue> valueSerializer, int parallelism, string dispatcherId, TimeSpan flushTimeout, IImmutableDictionary<string, object> properties)
+        public ProducerSettings(ISerializer<TKey> keySerializer, ISerializer<TValue> valueSerializer, int parallelism, 
+                                string dispatcherId, TimeSpan flushTimeout, IImmutableDictionary<string, string> properties)
         {
             KeySerializer = keySerializer;
             ValueSerializer = valueSerializer;
@@ -24,12 +25,12 @@ namespace Akka.Streams.Kafka.Settings
         public int Parallelism { get; }
         public string DispatcherId { get; }
         public TimeSpan FlushTimeout { get; }
-        public IImmutableDictionary<string, object> Properties { get; }
+        public IImmutableDictionary<string, string> Properties { get; }
 
         public ProducerSettings<TKey, TValue> WithBootstrapServers(string bootstrapServers) =>
             WithProperty("bootstrap.servers", bootstrapServers);
 
-        public ProducerSettings<TKey, TValue> WithProperty(string key, object value) =>
+        public ProducerSettings<TKey, TValue> WithProperty(string key, string value) =>
             Copy(properties: Properties.SetItem(key, value));
 
         public ProducerSettings<TKey, TValue> WithParallelism(int parallelism) =>
@@ -44,7 +45,7 @@ namespace Akka.Streams.Kafka.Settings
             int? parallelism = null,
             string dispatcherId = null,
             TimeSpan? flushTimeout = null,
-            IImmutableDictionary<string, object> properties = null) =>
+            IImmutableDictionary<string, string> properties = null) =>
             new ProducerSettings<TKey, TValue>(
                 keySerializer: keySerializer ?? this.KeySerializer,
                 valueSerializer: valueSerializer ?? this.ValueSerializer,
@@ -71,10 +72,16 @@ namespace Akka.Streams.Kafka.Settings
                 parallelism: config.GetInt("parallelism", 100),
                 dispatcherId: config.GetString("use-dispatcher", "akka.kafka.default-dispatcher"),
                 flushTimeout: config.GetTimeSpan("flush-timeout", TimeSpan.FromSeconds(2)),
-                properties: ImmutableDictionary<string, object>.Empty);
+                properties: ImmutableDictionary<string, string>.Empty);
         }
 
-        public Confluent.Kafka.IProducer<TKey, TValue> CreateKafkaProducer() =>
-            new Confluent.Kafka.Producer<TKey, TValue>(Properties, KeySerializer, ValueSerializer);
+        public Confluent.Kafka.IProducer<TKey, TValue> CreateKafkaProducer(Action<IProducer<TKey, TValue>, Error> producerErrorHandler = null)
+        {
+            return new Confluent.Kafka.ProducerBuilder<TKey, TValue>(Properties)
+                .SetKeySerializer(KeySerializer)
+                .SetValueSerializer(ValueSerializer)
+                .SetErrorHandler((p, error) => producerErrorHandler?.Invoke(p, error))
+                .Build();
+        }
     }
 }

--- a/src/Akka.Streams.Kafka/Stages/ConsumerStage.cs
+++ b/src/Akka.Streams.Kafka/Stages/ConsumerStage.cs
@@ -210,6 +210,24 @@ namespace Akka.Streams.Kafka.Stages
                 var exception = new KafkaException(error);
                 FailStage(exception);
             }
+            else if (KafkaExtensions.IsLocalValueSerializationError(error))
+            {
+                var exception = new SerializationException(error.Reason);
+                switch (_decider(exception))
+                {
+                    case Directive.Stop:
+                        // Throw
+                        _completion.TrySetException(exception);
+                        FailStage(exception);
+                        break;
+                    case Directive.Resume:
+                        // keep going
+                        break;
+                    case Directive.Restart:
+                        // keep going
+                        break;
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
The goal of this PR is to update Confluence.Kafka package version to latest (1.1.0).

While trying to keep PR as small as possible, big part of api, exposed by kafka, has been changed since old version. I did not touch current implementation design yet (so the buffering in consumer still exists), but still had to update code pretty much to make it compile and pass tests.

So, here is a list of changes:

1. There is no StringDeserializer anymore, and it is not needed because utf8 serializer used by default
2. Also there is no more MessageAndMeta class to wrap both topic info and message data. But it is useful to have stream of MessageAndMeta passed to producer, so I implemented it as a part of internal models.
3. ConsumeResult is our new ConsumerRecord (they just renamed it)
4. There are no events for incoming messages or partition assignments anymore - all handling should be configured using builder pattern when creating consumer/producer. So I removed all subscriptions, and passed handlers to consumer/producer creation factory:

 ```csharp
public Confluent.Kafka.IConsumer<TKey, TValue> CreateKafkaConsumer(Action<IConsumer<TKey, TValue>, Error> consumeErrorHandler = null,
                                                                   Action<IConsumer<TKey, TValue>, List<TopicPartition>> partitionAssignedHandler = null,
                                                                   Action<IConsumer<TKey, TValue>, List<TopicPartitionOffset>> partitionRevokedHandler = null)
{ 
    return new Confluent.Kafka.ConsumerBuilder<TKey, TValue>(this.Properties)
        .SetKeyDeserializer(this.KeyDeserializer)
        .SetValueDeserializer(this.ValueDeserializer)
        .SetErrorHandler((c, e) => consumeErrorHandler?.Invoke(c, e))
        .SetPartitionsAssignedHandler((c, partitions) => partitionAssignedHandler?.Invoke(c, partitions))
        .SetPartitionsRevokedHandler((c, partitions) => partitionRevokedHandler?.Invoke(c, partitions))
        .Build();
}
 ```

5. Pull is substituted by Consume, and the error handling was changed in this version - there is no OnError event anymore, we have to catch exceptions in place, like this:

 ```csharp
try
{
    var message = _consumer.Consume(_settings.PollTimeout);
    if (message == null)
        return;

    HandleMessage(message);
}
catch (ConsumeException ex)
{
    HandleError(ex.Error);
}
 ```

6. Most of the changes were make in consumer stages - and there is a lot of duplication for PlainSource and Commitable source - did not touch that yet, so you can see same changes applied twice to different classes.

This is my first PR, so any comments of how to make future PR's better are welcome!