### PR TITLE
Move tests to Docker.NET

### DIFF
--- a/src/Akka.Streams.Kafka.Tests/Akka.Streams.Kafka.Tests.csproj
+++ b/src/Akka.Streams.Kafka.Tests/Akka.Streams.Kafka.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
  <Import Project="..\common.props" />
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -8,6 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Akka.Streams.TestKit" Version="$(AkkaVersion)" />
     <PackageReference Include="Akka.TestKit.Xunit2" Version="$(AkkaVersion)" />
+    <PackageReference Include="Docker.DotNet" Version="3.125.2" />
     <PackageReference Include="FluentAssertions" Version="5.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
     <PackageReference Include="xunit" Version="$(XunitVersion)" />

--- a/src/Akka.Streams.Kafka.Tests/Integration/CommittableSourceIntegrationTests.cs
+++ b/src/Akka.Streams.Kafka.Tests/Integration/CommittableSourceIntegrationTests.cs
@@ -15,17 +15,17 @@ using Xunit.Abstractions;
 
 namespace Akka.Streams.Kafka.Tests.Integration
 {
+    [Collection(KafkaSpecsFixture.Name)]
     public class CommittableSourceIntegrationTests : Akka.TestKit.Xunit2.TestKit
     {
-        private const string KafkaUrl = "localhost:29092";
-
         private const string InitialMsg = "initial msg in topic, required to create the topic before any consumer subscribes to it";
-
+        private readonly KafkaFixture _fixture;
         private readonly ActorMaterializer _materializer;
 
-        public CommittableSourceIntegrationTests(ITestOutputHelper output) 
+        public CommittableSourceIntegrationTests(ITestOutputHelper output, KafkaFixture fixture) 
             : base(ConfigurationFactory.FromResource<ConsumerSettings<object, object>>("Akka.Streams.Kafka.reference.conf"), null, output)
         {
+            _fixture = fixture;
             _materializer = Sys.Materializer();
         }
 
@@ -34,9 +34,10 @@ namespace Akka.Streams.Kafka.Tests.Integration
         private string CreateTopic(int number) => $"topic-{number}-{Uuid}";
         private string CreateGroup(int number) => $"group-{number}-{Uuid}";
 
-        private ProducerSettings<Null, string> ProducerSettings =>
-            ProducerSettings<Null, string>.Create(Sys, null, null)
-                .WithBootstrapServers(KafkaUrl);
+        private ProducerSettings<Null, string> ProducerSettings
+        {
+            get => ProducerSettings<Null, string>.Create(Sys, null, null).WithBootstrapServers(_fixture.KafkaServer);
+        }
 
         private async Task GivenInitializedTopic(string topic)
         {
@@ -49,7 +50,7 @@ namespace Akka.Streams.Kafka.Tests.Integration
         private ConsumerSettings<Null, string> CreateConsumerSettings(string group)
         {
             return ConsumerSettings<Null, string>.Create(Sys, null, null)
-                .WithBootstrapServers(KafkaUrl)
+                .WithBootstrapServers(_fixture.KafkaServer)
                 .WithProperty("auto.offset.reset", "earliest")
                 .WithGroupId(group);
         }

--- a/src/Akka.Streams.Kafka.Tests/Integration/PlainSinkIntegrationTests.cs
+++ b/src/Akka.Streams.Kafka.Tests/Integration/PlainSinkIntegrationTests.cs
@@ -16,9 +16,10 @@ using Xunit.Abstractions;
 
 namespace Akka.Streams.Kafka.Tests.Integration
 {
+    [Collection(KafkaSpecsFixture.Name)]
     public class PlainSinkIntegrationTests : Akka.TestKit.Xunit2.TestKit
     {
-        private const string KafkaUrl = "localhost:29092";
+        private readonly KafkaFixture _fixture;
         private const string InitialMsg = "initial msg in topic, required to create the topic before any consumer subscribes to it";
         private readonly ActorMaterializer _materializer;
 
@@ -27,10 +28,11 @@ namespace Akka.Streams.Kafka.Tests.Integration
         private string CreateTopic(int number) => $"topic-{number}-{Uuid}";
         private string CreateGroup(int number) => $"group-{number}-{Uuid}";
 
-        public PlainSinkIntegrationTests(ITestOutputHelper output) 
+        public PlainSinkIntegrationTests(ITestOutputHelper output, KafkaFixture fixture) 
             : base(ConfigurationFactory
                 .FromResource<ConsumerSettings<object, object>>("Akka.Streams.Kafka.reference.conf"), null, output)
         {
+            _fixture = fixture;
             _materializer = Sys.Materializer();
         }
 
@@ -42,14 +44,15 @@ namespace Akka.Streams.Kafka.Tests.Integration
             }
         }
 
-        private ProducerSettings<Null, string> ProducerSettings =>
-            ProducerSettings<Null, string>.Create(Sys, null, null)
-                .WithBootstrapServers(KafkaUrl);
+        private ProducerSettings<Null, string> ProducerSettings
+        {
+            get => ProducerSettings<Null, string>.Create(Sys, null, null).WithBootstrapServers(_fixture.KafkaServer);
+        }
 
         private ConsumerSettings<Null, string> CreateConsumerSettings(string group)
         {
             return ConsumerSettings<Null, string>.Create(Sys, null, null)
-                .WithBootstrapServers(KafkaUrl)
+                .WithBootstrapServers(_fixture.KafkaServer)
                 .WithProperty("auto.offset.reset", "earliest")
                 .WithGroupId(group);
         }

--- a/src/Akka.Streams.Kafka.Tests/Integration/PlainSourceIntegrationTests.cs
+++ b/src/Akka.Streams.Kafka.Tests/Integration/PlainSourceIntegrationTests.cs
@@ -19,25 +19,26 @@ using Config = Akka.Configuration.Config;
 
 namespace Akka.Streams.Kafka.Tests.Integration
 {
+    [Collection(KafkaSpecsFixture.Name)]
     public class PlainSourceIntegrationTests : Akka.TestKit.Xunit2.TestKit
     {
-        private const string KafkaUrl = "localhost:29092";
-
         private const string InitialMsg = "initial msg in topic, required to create the topic before any consumer subscribes to it";
-
+        
+        private readonly KafkaFixture _fixture;
         private readonly ActorMaterializer _materializer;
 
-        public static Config Default()
-        {
-            return ConfigurationFactory.ParseString("akka.loglevel = DEBUG")
-                .WithFallback(ConfigurationFactory.FromResource<ConsumerSettings<object, object>>(
-                        "Akka.Streams.Kafka.reference.conf"));
-        }
-
-        public PlainSourceIntegrationTests(ITestOutputHelper output) 
+        public PlainSourceIntegrationTests(ITestOutputHelper output, KafkaFixture fixture) 
             : base(Default(), nameof(PlainSourceIntegrationTests), output)
         {
+            _fixture = fixture;
             _materializer = Sys.Materializer();
+        }
+
+        private static Config Default()
+        {
+            var defaultSettings = ConfigurationFactory.FromResource<ConsumerSettings<object, object>>("Akka.Streams.Kafka.reference.conf");
+            
+            return ConfigurationFactory.ParseString("akka.loglevel = DEBUG").WithFallback(defaultSettings);
         }
 
         private string Uuid { get; } = Guid.NewGuid().ToString();
@@ -45,10 +46,19 @@ namespace Akka.Streams.Kafka.Tests.Integration
         private string CreateTopic(int number) => $"topic-{number}-{Uuid}";
         private string CreateGroup(int number) => $"group-{number}-{Uuid}";
 
-        private ProducerSettings<Null, string> ProducerSettings =>
-            ProducerSettings<Null, string>.Create(Sys, null, null)
-                .WithBootstrapServers(KafkaUrl);
+        private ProducerSettings<Null, string> ProducerSettings
+        {
+            get => ProducerSettings<Null, string>.Create(Sys, null, null).WithBootstrapServers(_fixture.KafkaServer);
+        }
 
+        private ConsumerSettings<Null, string> CreateConsumerSettings(string group)
+        {
+            return ConsumerSettings<Null, string>.Create(Sys, null, null)
+                .WithBootstrapServers(_fixture.KafkaServer)
+                .WithProperty("auto.offset.reset", "earliest")
+                .WithGroupId(group);
+        }
+        
         private async Task GivenInitializedTopic(string topic)
         {
             using (var producer = ProducerSettings.CreateKafkaProducer())
@@ -56,14 +66,6 @@ namespace Akka.Streams.Kafka.Tests.Integration
                 await producer.ProduceAsync(topic, new Message<Null, string> { Value = InitialMsg });
                 producer.Flush(TimeSpan.FromSeconds(1));
             }
-        }
-
-        private ConsumerSettings<Null, string> CreateConsumerSettings(string group)
-        {
-            return ConsumerSettings<Null, string>.Create(Sys, null, null)
-                .WithBootstrapServers(KafkaUrl)
-                .WithProperty("auto.offset.reset", "earliest")
-                .WithGroupId(group);
         }
 
         private async Task Produce(string topic, IEnumerable<int> range, ProducerSettings<Null, string> producerSettings)
@@ -74,7 +76,7 @@ namespace Akka.Streams.Kafka.Tests.Integration
                 .RunWith(KafkaProducer.PlainSink(producerSettings), _materializer);
         }
 
-        private TestSubscriber.Probe<string> CreateProbe(ConsumerSettings<Null, string> consumerSettings, string topic, ISubscription sub)
+        private TestSubscriber.Probe<string> CreateProbe(ConsumerSettings<Null, string> consumerSettings, ISubscription sub)
         {
             return KafkaConsumer
                 .PlainSource(consumerSettings, sub)
@@ -96,7 +98,7 @@ namespace Akka.Streams.Kafka.Tests.Integration
 
             var consumerSettings = CreateConsumerSettings(group1);
 
-            var probe = CreateProbe(consumerSettings, topic1, Subscriptions.Assignment(new TopicPartition(topic1, 0)));
+            var probe = CreateProbe(consumerSettings, Subscriptions.Assignment(new TopicPartition(topic1, 0)));
             
             probe.Request(elementsCount);
             foreach (var i in Enumerable.Range(1, elementsCount).Select(c => c.ToString()))
@@ -119,7 +121,7 @@ namespace Akka.Streams.Kafka.Tests.Integration
 
             var consumerSettings = CreateConsumerSettings(group1);
 
-            var probe = CreateProbe(consumerSettings, topic1, Subscriptions.AssignmentWithOffset(new TopicPartitionOffset(topic1, 0, new Offset(offset))));
+            var probe = CreateProbe(consumerSettings, Subscriptions.AssignmentWithOffset(new TopicPartitionOffset(topic1, 0, new Offset(offset))));
 
             probe.Request(elementsCount);
             foreach (var i in Enumerable.Range(offset, elementsCount - offset).Select(c => c.ToString()))
@@ -141,7 +143,7 @@ namespace Akka.Streams.Kafka.Tests.Integration
 
             var consumerSettings = CreateConsumerSettings(group1);
 
-            var probe = CreateProbe(consumerSettings, topic1, Subscriptions.Topics(topic1));
+            var probe = CreateProbe(consumerSettings, Subscriptions.Topics(topic1));
 
             probe.Request(elementsCount);
             foreach (var i in Enumerable.Range(1, elementsCount).Select(c => c.ToString()))
@@ -162,7 +164,7 @@ namespace Akka.Streams.Kafka.Tests.Integration
                 .WithBootstrapServers("localhost:10092")
                 .WithGroupId(group1);
 
-            var probe = CreateProbe(config, topic1, Subscriptions.Assignment(new TopicPartition(topic1, 0)));
+            var probe = CreateProbe(config, Subscriptions.Assignment(new TopicPartition(topic1, 0)));
             probe.Request(1).ExpectError().Should().BeOfType<KafkaException>();
         }
 
@@ -176,7 +178,7 @@ namespace Akka.Streams.Kafka.Tests.Integration
             await Produce(topic1, Enumerable.Range(1, elementsCount), ProducerSettings);
 
             var settings = ConsumerSettings<Null, int>.Create(Sys, null, Deserializers.Int32)
-                .WithBootstrapServers(KafkaUrl)
+                .WithBootstrapServers(_fixture.KafkaServer)
                 .WithProperty("auto.offset.reset", "earliest")
                 .WithGroupId(group1);
 
@@ -206,7 +208,7 @@ namespace Akka.Streams.Kafka.Tests.Integration
             await Produce(topic1, Enumerable.Range(1, elementsCount), ProducerSettings);
 
             var settings = ConsumerSettings<Null, int>.Create(Sys, null, Deserializers.Int32)
-                .WithBootstrapServers(KafkaUrl)
+                .WithBootstrapServers(_fixture.KafkaServer)
                 .WithProperty("auto.offset.reset", "earliest")
                 .WithGroupId(group1);
 

--- a/src/Akka.Streams.Kafka.Tests/KafkaFixture.cs
+++ b/src/Akka.Streams.Kafka.Tests/KafkaFixture.cs
@@ -1,0 +1,161 @@
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using Akka.Util;
+using Docker.DotNet;
+using Docker.DotNet.Models;
+using Xunit;
+
+namespace Akka.Streams.Kafka.Tests
+{
+    [CollectionDefinition(Name)]
+    public sealed class KafkaSpecsFixture : ICollectionFixture<KafkaFixture>
+    {
+        public const string Name = "KafkaSpecs";
+    }
+    
+    public class KafkaFixture : IAsyncLifetime
+    {
+        private const string KafkaImageName = "confluentinc/cp-kafka";
+        private const string KafkaImageTag = "4.0.0";
+        private const string ZookeeperImageName = "confluentinc/cp-zookeeper";
+        private const string ZookeeperImageTag = "4.0.0";
+        
+        private readonly string _kafkaContainerName = $"kafka-{Guid.NewGuid():N}";
+        private readonly string _zookeeperContainerName = $"zookeeper-{Guid.NewGuid():N}";
+        private readonly string _networkName = $"network-{Guid.NewGuid():N}";
+        
+        private readonly DockerClient _client;
+        
+        public KafkaFixture()
+        {
+            DockerClientConfiguration config;
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                config = new DockerClientConfiguration(new Uri("unix://var/run/docker.sock"));
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                config = new DockerClientConfiguration(new Uri("npipe://./pipe/docker_engine"));
+            else
+                throw new NotSupportedException($"Unsupported OS [{RuntimeInformation.OSDescription}]");
+
+            _client = config.CreateClient();
+        }
+        
+        public int KafkaPort { get; private set; }
+        public string KafkaServer => $"localhost:{KafkaPort}";
+
+        public async Task InitializeAsync()
+        {
+            await EnsureImageExists(ZookeeperImageName, ZookeeperImageTag);
+            await EnsureImageExists(KafkaImageName, KafkaImageTag);
+
+            var zookeeperPort = ThreadLocalRandom.Current.Next(32000, 33000);
+            KafkaPort = ThreadLocalRandom.Current.Next(28000, 29000);
+
+            // create the containers
+            await CreateContainer(ZookeeperImageName, ZookeeperImageTag, _zookeeperContainerName, zookeeperPort, new Dictionary<string, string>()
+            {
+                ["ZOOKEEPER_CLIENT_PORT"] = zookeeperPort.ToString(),
+                ["ZOOKEEPER_TICK_TIME"] = "2000",
+            });
+            await CreateContainer(KafkaImageName, KafkaImageTag, _kafkaContainerName, KafkaPort, new Dictionary<string, string>()
+            {
+                ["KAFKA_BROKER_ID"] = "1",
+                ["KAFKA_ZOOKEEPER_CONNECT"] = $"{_zookeeperContainerName}:{zookeeperPort}",
+                ["KAFKA_ADVERTISED_LISTENERS"] = $"PLAINTEXT://localhost:{KafkaPort}",
+                ["KAFKA_AUTO_CREATE_TOPICS_ENABLE"] = "true",
+                ["KAFKA_DELETE_TOPIC_ENABLE"] = "true",
+                ["KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR"] = "1"
+            });
+
+            var network = await _client.Networks.CreateNetworkAsync(new NetworksCreateParameters(new NetworkCreate())
+            {
+                Name = _networkName
+            });
+            await _client.Networks.ConnectNetworkAsync(network.ID, new NetworkConnectParameters()
+            {
+                Container = _kafkaContainerName
+            });
+            await _client.Networks.ConnectNetworkAsync(network.ID, new NetworkConnectParameters()
+            {
+                Container = _zookeeperContainerName
+            });
+
+            // start the containers
+            await _client.Containers.StartContainerAsync(_zookeeperContainerName, new ContainerStartParameters());
+            await _client.Containers.StartContainerAsync(_kafkaContainerName, new ContainerStartParameters());
+
+            // Provide a 10 second startup delay
+            await Task.Delay(TimeSpan.FromSeconds(10));
+        }
+
+        public async Task DisposeAsync()
+        {
+            if (_client != null)
+            {
+                // Stop Kafka
+                await _client.Containers.StopContainerAsync(_kafkaContainerName, new ContainerStopParameters());
+                await _client.Containers.RemoveContainerAsync(_kafkaContainerName, new ContainerRemoveParameters { Force = true });
+                
+                // Stop Zookeeper
+                await _client.Containers.StopContainerAsync(_zookeeperContainerName, new ContainerStopParameters());
+                await _client.Containers.RemoveContainerAsync(_zookeeperContainerName, new ContainerRemoveParameters { Force = true });
+
+                await _client.Networks.DeleteNetworkAsync(_networkName);
+                
+                _client.Dispose();
+            }
+        }
+        
+        private async Task CreateContainer(string imageName, string imageTag, string containerName, int portToExpose, Dictionary<string, string> env)
+        {
+            await _client.Containers.CreateContainerAsync(new CreateContainerParameters
+            {
+                Image = $"{imageName}:{imageTag}",
+                Name = containerName,
+                Tty = true,
+                
+                ExposedPorts = new Dictionary<string, EmptyStruct>
+                {
+                    {$"{portToExpose}/tcp", new EmptyStruct()}
+                },
+                HostConfig = new HostConfig
+                {
+                    PortBindings = new Dictionary<string, IList<PortBinding>>
+                    {
+                        {
+                            $"{portToExpose}/tcp",
+                            new List<PortBinding>
+                            {
+                                new PortBinding
+                                {
+                                    HostPort = $"{portToExpose}"
+                                }
+                            }
+                        }
+                    },
+                    ExtraHosts = new [] { "moby:127.0.0.1", "localhost:127.0.0.1" },
+                },
+                Env = env.Select(pair => $"{pair.Key}={pair.Value}").ToArray(),
+            });
+        }
+
+        private async Task EnsureImageExists(string imageName, string imageTag)
+        {
+            var existingImages = await _client.Images.ListImagesAsync(new ImagesListParameters { MatchName = imageName });
+            if (existingImages.Count == 0)
+            {
+                await _client.Images.CreateImageAsync(
+                    new ImagesCreateParameters {FromImage = imageName, Tag = imageTag }, null,
+                    new Progress<JSONMessage>(message =>
+                    {
+                        Console.WriteLine(!string.IsNullOrEmpty(message.ErrorMessage)
+                            ? message.ErrorMessage
+                            : $"{message.ID} {message.Status} {message.ProgressMessage}");
+                    }));
+            }
+        }
+    }
+}

--- a/src/Akka.Streams.Kafka.Tests/KafkaFixture.cs
+++ b/src/Akka.Streams.Kafka.Tests/KafkaFixture.cs
@@ -20,9 +20,9 @@ namespace Akka.Streams.Kafka.Tests
     public class KafkaFixture : IAsyncLifetime
     {
         private const string KafkaImageName = "confluentinc/cp-kafka";
-        private const string KafkaImageTag = "4.0.0";
+        private const string KafkaImageTag = "latest";
         private const string ZookeeperImageName = "confluentinc/cp-zookeeper";
-        private const string ZookeeperImageTag = "4.0.0";
+        private const string ZookeeperImageTag = "latest";
         
         private readonly string _kafkaContainerName = $"kafka-{Guid.NewGuid():N}";
         private readonly string _zookeeperContainerName = $"zookeeper-{Guid.NewGuid():N}";
@@ -144,11 +144,11 @@ namespace Akka.Streams.Kafka.Tests
 
         private async Task EnsureImageExists(string imageName, string imageTag)
         {
-            var existingImages = await _client.Images.ListImagesAsync(new ImagesListParameters { MatchName = imageName });
+            var existingImages = await _client.Images.ListImagesAsync(new ImagesListParameters { MatchName = $"{imageName}:{imageTag}" });
             if (existingImages.Count == 0)
             {
                 await _client.Images.CreateImageAsync(
-                    new ImagesCreateParameters {FromImage = imageName, Tag = imageTag }, null,
+                    new ImagesCreateParameters { FromImage = imageName, Tag = imageTag }, null,
                     new Progress<JSONMessage>(message =>
                     {
                         Console.WriteLine(!string.IsNullOrEmpty(message.ErrorMessage)


### PR DESCRIPTION
This PR is about using Docker.NET in tests, issue #34 .

As simple as adding `KafkaFixture` to set up containers on random ports, execute tests and shutdown containers.

_Note_: kafka container requires zookeeper container to be running, so the setup is little bit more complicated then for single `SqlServer` container referenced in issue #34 . Well, the most important difference is using user-defined network to allow kafka communicate with zookeeper directly.

_Other note_: this did not help all tests to be stable. Sometimes I get most of them passing, sometimes some of them freezing forever. Fixing tests is not the goal of this PR, so will back to this after updating stages implementation (see #35 )

Close #34 