### PR TITLE
Remove timer and buffering from source stages

### DIFF
--- a/src/Akka.Streams.Kafka/Stages/ConsumerStage.cs
+++ b/src/Akka.Streams.Kafka/Stages/ConsumerStage.cs
@@ -63,7 +63,7 @@ namespace Akka.Streams.Kafka.Stages
                 try
                 {
                     var message = _consumer.Consume(_cancellationTokenSource.Token);
-                    if (message == null) // Sone error occured, nothing to do here
+                    if (message == null) // No message received, or consume error occured
                         return;
 
                     if (IsAvailable(stage.Out))


### PR DESCRIPTION
This PR is assigned to issue #35 . 

Most changes are duplicating between ConsumerStage and CommittableConsumerStage - that is because they are very similar. We should refactor them to inherit common logic from some base class  - well, how this is implemented in alpakka-kafka project (so this is going to be a part of issue #36 I guess)

At least one of the tests is still failing - this one:
https://github.com/akkadotnet/Akka.Streams.Kafka/blob/c609061bab16e846f953dcc605b90627a58d3544/src/Akka.Streams.Kafka.Tests/Integration/CommittableSourceIntegrationTests.cs#L57-L58

I checked out it's implementation in alpakka and there is a difference which may lead to race conditions and fail tests. This will be solved in issue #39 .
Also, in this PR all tests should fail because this update is independent from PR #38 and thus does not use Docker.NET to run containers during tests.
