### PR TITLE
Make tests pass

### DIFF
--- a/src/Akka.Streams.Kafka.Tests/Akka.Streams.Kafka.Tests.csproj
+++ b/src/Akka.Streams.Kafka.Tests/Akka.Streams.Kafka.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
  <Import Project="..\common.props" />
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -8,6 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Akka.Streams.TestKit" Version="$(AkkaVersion)" />
     <PackageReference Include="Akka.TestKit.Xunit2" Version="$(AkkaVersion)" />
+    <PackageReference Include="Docker.DotNet" Version="3.125.2" />
     <PackageReference Include="FluentAssertions" Version="5.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
     <PackageReference Include="xunit" Version="$(XunitVersion)" />

--- a/src/Akka.Streams.Kafka.Tests/Extensions.cs
+++ b/src/Akka.Streams.Kafka.Tests/Extensions.cs
@@ -1,0 +1,22 @@
+using System.Reflection;
+using Xunit.Abstractions;
+
+namespace Akka.Streams.Kafka.Tests
+{
+    /// <summary>
+    /// Extensions
+    /// </summary>
+    public static class Extensions
+    {
+        /// <summary>
+        /// Gets current test name
+        /// </summary>
+        public static string GetCurrentTestName(this ITestOutputHelper output)
+        {
+            var type = output.GetType();
+            var testMember = type.GetField("test", BindingFlags.Instance | BindingFlags.NonPublic);
+            var test = (ITest)testMember.GetValue(output);
+            return test.DisplayName;
+        }
+    }
+}

--- a/src/Akka.Streams.Kafka.Tests/Integration/CommittableSourceIntegrationTests.cs
+++ b/src/Akka.Streams.Kafka.Tests/Integration/CommittableSourceIntegrationTests.cs
@@ -12,18 +12,18 @@ using Akka.Streams.TestKit;
 using Confluent.Kafka;
 using Xunit;
 using Xunit.Abstractions;
+using Config = Akka.Configuration.Config;
 
 namespace Akka.Streams.Kafka.Tests.Integration
 {
-    [Collection(KafkaSpecsFixture.Name)]
-    public class CommittableSourceIntegrationTests : Akka.TestKit.Xunit2.TestKit
+    public class CommittableSourceIntegrationTests : KafkaIntegrationTests
     {
         private const string InitialMsg = "initial msg in topic, required to create the topic before any consumer subscribes to it";
         private readonly KafkaFixture _fixture;
         private readonly ActorMaterializer _materializer;
 
         public CommittableSourceIntegrationTests(ITestOutputHelper output, KafkaFixture fixture) 
-            : base(ConfigurationFactory.FromResource<ConsumerSettings<object, object>>("Akka.Streams.Kafka.reference.conf"), null, output)
+            : base(nameof(CommittableSourceIntegrationTests), output)
         {
             _fixture = fixture;
             _materializer = Sys.Materializer();

--- a/src/Akka.Streams.Kafka.Tests/Integration/CommittableSourceIntegrationTests.cs
+++ b/src/Akka.Streams.Kafka.Tests/Integration/CommittableSourceIntegrationTests.cs
@@ -101,7 +101,7 @@ namespace Akka.Streams.Kafka.Tests.Integration
             var consumerSettings = CreateConsumerSettings(group1);
             var committedElements = new ConcurrentQueue<string>();
 
-            var (_, probe1) = KafkaConsumer.CommittableSource(consumerSettings, Subscriptions.Assignment(new TopicPartition(topic1, 0)))
+            var (task, probe1) = KafkaConsumer.CommittableSource(consumerSettings, Subscriptions.Assignment(new TopicPartition(topic1, 0)))
                 .WhereNot(c => c.Record.Value == InitialMsg)
                 .SelectAsync(10, elem =>
                 {
@@ -121,7 +121,7 @@ namespace Akka.Streams.Kafka.Tests.Integration
                 
             probe1.Cancel();
 
-            // Await.result(control.isShutdown, remainingOrDefault)
+            AwaitCondition(() => task.IsCompleted);
 
             var probe2 = KafkaConsumer.CommittableSource(consumerSettings, Subscriptions.Assignment(new TopicPartition(topic1, 0)))
                 .Select(_ => _.Record.Value)

--- a/src/Akka.Streams.Kafka.Tests/Integration/CommittableSourceIntegrationTests.cs
+++ b/src/Akka.Streams.Kafka.Tests/Integration/CommittableSourceIntegrationTests.cs
@@ -15,17 +15,17 @@ using Xunit.Abstractions;
 
 namespace Akka.Streams.Kafka.Tests.Integration
 {
+    [Collection(KafkaSpecsFixture.Name)]
     public class CommittableSourceIntegrationTests : Akka.TestKit.Xunit2.TestKit
     {
-        private const string KafkaUrl = "localhost:29092";
-
         private const string InitialMsg = "initial msg in topic, required to create the topic before any consumer subscribes to it";
-
+        private readonly KafkaFixture _fixture;
         private readonly ActorMaterializer _materializer;
 
-        public CommittableSourceIntegrationTests(ITestOutputHelper output) 
+        public CommittableSourceIntegrationTests(ITestOutputHelper output, KafkaFixture fixture) 
             : base(ConfigurationFactory.FromResource<ConsumerSettings<object, object>>("Akka.Streams.Kafka.reference.conf"), null, output)
         {
+            _fixture = fixture;
             _materializer = Sys.Materializer();
         }
 
@@ -34,9 +34,10 @@ namespace Akka.Streams.Kafka.Tests.Integration
         private string CreateTopic(int number) => $"topic-{number}-{Uuid}";
         private string CreateGroup(int number) => $"group-{number}-{Uuid}";
 
-        private ProducerSettings<Null, string> ProducerSettings =>
-            ProducerSettings<Null, string>.Create(Sys, null, null)
-                .WithBootstrapServers(KafkaUrl);
+        private ProducerSettings<Null, string> ProducerSettings
+        {
+            get => ProducerSettings<Null, string>.Create(Sys, null, null).WithBootstrapServers(_fixture.KafkaServer);
+        }
 
         private async Task GivenInitializedTopic(string topic)
         {
@@ -49,7 +50,7 @@ namespace Akka.Streams.Kafka.Tests.Integration
         private ConsumerSettings<Null, string> CreateConsumerSettings(string group)
         {
             return ConsumerSettings<Null, string>.Create(Sys, null, null)
-                .WithBootstrapServers(KafkaUrl)
+                .WithBootstrapServers(_fixture.KafkaServer)
                 .WithProperty("auto.offset.reset", "earliest")
                 .WithGroupId(group);
         }

--- a/src/Akka.Streams.Kafka.Tests/Integration/PlainSinkIntegrationTests.cs
+++ b/src/Akka.Streams.Kafka.Tests/Integration/PlainSinkIntegrationTests.cs
@@ -16,8 +16,7 @@ using Xunit.Abstractions;
 
 namespace Akka.Streams.Kafka.Tests.Integration
 {
-    [Collection(KafkaSpecsFixture.Name)]
-    public class PlainSinkIntegrationTests : Akka.TestKit.Xunit2.TestKit
+    public class PlainSinkIntegrationTests : KafkaIntegrationTests
     {
         private readonly KafkaFixture _fixture;
         private const string InitialMsg = "initial msg in topic, required to create the topic before any consumer subscribes to it";
@@ -29,8 +28,7 @@ namespace Akka.Streams.Kafka.Tests.Integration
         private string CreateGroup(int number) => $"group-{number}-{Uuid}";
 
         public PlainSinkIntegrationTests(ITestOutputHelper output, KafkaFixture fixture) 
-            : base(ConfigurationFactory
-                .FromResource<ConsumerSettings<object, object>>("Akka.Streams.Kafka.reference.conf"), null, output)
+            : base(null, output)
         {
             _fixture = fixture;
             _materializer = Sys.Materializer();

--- a/src/Akka.Streams.Kafka.Tests/Integration/PlainSinkIntegrationTests.cs
+++ b/src/Akka.Streams.Kafka.Tests/Integration/PlainSinkIntegrationTests.cs
@@ -16,9 +16,10 @@ using Xunit.Abstractions;
 
 namespace Akka.Streams.Kafka.Tests.Integration
 {
+    [Collection(KafkaSpecsFixture.Name)]
     public class PlainSinkIntegrationTests : Akka.TestKit.Xunit2.TestKit
     {
-        private const string KafkaUrl = "localhost:29092";
+        private readonly KafkaFixture _fixture;
         private const string InitialMsg = "initial msg in topic, required to create the topic before any consumer subscribes to it";
         private readonly ActorMaterializer _materializer;
 
@@ -27,10 +28,11 @@ namespace Akka.Streams.Kafka.Tests.Integration
         private string CreateTopic(int number) => $"topic-{number}-{Uuid}";
         private string CreateGroup(int number) => $"group-{number}-{Uuid}";
 
-        public PlainSinkIntegrationTests(ITestOutputHelper output) 
+        public PlainSinkIntegrationTests(ITestOutputHelper output, KafkaFixture fixture) 
             : base(ConfigurationFactory
                 .FromResource<ConsumerSettings<object, object>>("Akka.Streams.Kafka.reference.conf"), null, output)
         {
+            _fixture = fixture;
             _materializer = Sys.Materializer();
         }
 
@@ -42,14 +44,15 @@ namespace Akka.Streams.Kafka.Tests.Integration
             }
         }
 
-        private ProducerSettings<Null, string> ProducerSettings =>
-            ProducerSettings<Null, string>.Create(Sys, null, null)
-                .WithBootstrapServers(KafkaUrl);
+        private ProducerSettings<Null, string> ProducerSettings
+        {
+            get => ProducerSettings<Null, string>.Create(Sys, null, null).WithBootstrapServers(_fixture.KafkaServer);
+        }
 
         private ConsumerSettings<Null, string> CreateConsumerSettings(string group)
         {
             return ConsumerSettings<Null, string>.Create(Sys, null, null)
-                .WithBootstrapServers(KafkaUrl)
+                .WithBootstrapServers(_fixture.KafkaServer)
                 .WithProperty("auto.offset.reset", "earliest")
                 .WithGroupId(group);
         }

--- a/src/Akka.Streams.Kafka.Tests/Integration/PlainSourceIntegrationTests.cs
+++ b/src/Akka.Streams.Kafka.Tests/Integration/PlainSourceIntegrationTests.cs
@@ -19,25 +19,26 @@ using Config = Akka.Configuration.Config;
 
 namespace Akka.Streams.Kafka.Tests.Integration
 {
+    [Collection(KafkaSpecsFixture.Name)]
     public class PlainSourceIntegrationTests : Akka.TestKit.Xunit2.TestKit
     {
-        private const string KafkaUrl = "localhost:29092";
-
         private const string InitialMsg = "initial msg in topic, required to create the topic before any consumer subscribes to it";
-
+        
+        private readonly KafkaFixture _fixture;
         private readonly ActorMaterializer _materializer;
 
-        public static Config Default()
-        {
-            return ConfigurationFactory.ParseString("akka.loglevel = DEBUG")
-                .WithFallback(ConfigurationFactory.FromResource<ConsumerSettings<object, object>>(
-                        "Akka.Streams.Kafka.reference.conf"));
-        }
-
-        public PlainSourceIntegrationTests(ITestOutputHelper output) 
+        public PlainSourceIntegrationTests(ITestOutputHelper output, KafkaFixture fixture) 
             : base(Default(), nameof(PlainSourceIntegrationTests), output)
         {
+            _fixture = fixture;
             _materializer = Sys.Materializer();
+        }
+
+        private static Config Default()
+        {
+            var defaultSettings = ConfigurationFactory.FromResource<ConsumerSettings<object, object>>("Akka.Streams.Kafka.reference.conf");
+            
+            return ConfigurationFactory.ParseString("akka.loglevel = DEBUG").WithFallback(defaultSettings);
         }
 
         private string Uuid { get; } = Guid.NewGuid().ToString();
@@ -45,10 +46,19 @@ namespace Akka.Streams.Kafka.Tests.Integration
         private string CreateTopic(int number) => $"topic-{number}-{Uuid}";
         private string CreateGroup(int number) => $"group-{number}-{Uuid}";
 
-        private ProducerSettings<Null, string> ProducerSettings =>
-            ProducerSettings<Null, string>.Create(Sys, null, null)
-                .WithBootstrapServers(KafkaUrl);
+        private ProducerSettings<Null, string> ProducerSettings
+        {
+            get => ProducerSettings<Null, string>.Create(Sys, null, null).WithBootstrapServers(_fixture.KafkaServer);
+        }
 
+        private ConsumerSettings<Null, string> CreateConsumerSettings(string group)
+        {
+            return ConsumerSettings<Null, string>.Create(Sys, null, null)
+                .WithBootstrapServers(_fixture.KafkaServer)
+                .WithProperty("auto.offset.reset", "earliest")
+                .WithGroupId(group);
+        }
+        
         private async Task GivenInitializedTopic(string topic)
         {
             using (var producer = ProducerSettings.CreateKafkaProducer())
@@ -56,14 +66,6 @@ namespace Akka.Streams.Kafka.Tests.Integration
                 await producer.ProduceAsync(topic, new Message<Null, string> { Value = InitialMsg });
                 producer.Flush(TimeSpan.FromSeconds(1));
             }
-        }
-
-        private ConsumerSettings<Null, string> CreateConsumerSettings(string group)
-        {
-            return ConsumerSettings<Null, string>.Create(Sys, null, null)
-                .WithBootstrapServers(KafkaUrl)
-                .WithProperty("auto.offset.reset", "earliest")
-                .WithGroupId(group);
         }
 
         private async Task Produce(string topic, IEnumerable<int> range, ProducerSettings<Null, string> producerSettings)
@@ -74,7 +76,7 @@ namespace Akka.Streams.Kafka.Tests.Integration
                 .RunWith(KafkaProducer.PlainSink(producerSettings), _materializer);
         }
 
-        private TestSubscriber.Probe<string> CreateProbe(ConsumerSettings<Null, string> consumerSettings, string topic, ISubscription sub)
+        private TestSubscriber.Probe<string> CreateProbe(ConsumerSettings<Null, string> consumerSettings, ISubscription sub)
         {
             return KafkaConsumer
                 .PlainSource(consumerSettings, sub)
@@ -96,7 +98,7 @@ namespace Akka.Streams.Kafka.Tests.Integration
 
             var consumerSettings = CreateConsumerSettings(group1);
 
-            var probe = CreateProbe(consumerSettings, topic1, Subscriptions.Assignment(new TopicPartition(topic1, 0)));
+            var probe = CreateProbe(consumerSettings, Subscriptions.Assignment(new TopicPartition(topic1, 0)));
             
             probe.Request(elementsCount);
             foreach (var i in Enumerable.Range(1, elementsCount).Select(c => c.ToString()))
@@ -119,7 +121,7 @@ namespace Akka.Streams.Kafka.Tests.Integration
 
             var consumerSettings = CreateConsumerSettings(group1);
 
-            var probe = CreateProbe(consumerSettings, topic1, Subscriptions.AssignmentWithOffset(new TopicPartitionOffset(topic1, 0, new Offset(offset))));
+            var probe = CreateProbe(consumerSettings, Subscriptions.AssignmentWithOffset(new TopicPartitionOffset(topic1, 0, new Offset(offset))));
 
             probe.Request(elementsCount);
             foreach (var i in Enumerable.Range(offset, elementsCount - offset).Select(c => c.ToString()))
@@ -141,7 +143,7 @@ namespace Akka.Streams.Kafka.Tests.Integration
 
             var consumerSettings = CreateConsumerSettings(group1);
 
-            var probe = CreateProbe(consumerSettings, topic1, Subscriptions.Topics(topic1));
+            var probe = CreateProbe(consumerSettings, Subscriptions.Topics(topic1));
 
             probe.Request(elementsCount);
             foreach (var i in Enumerable.Range(1, elementsCount).Select(c => c.ToString()))
@@ -162,7 +164,7 @@ namespace Akka.Streams.Kafka.Tests.Integration
                 .WithBootstrapServers("localhost:10092")
                 .WithGroupId(group1);
 
-            var probe = CreateProbe(config, topic1, Subscriptions.Assignment(new TopicPartition(topic1, 0)));
+            var probe = CreateProbe(config, Subscriptions.Assignment(new TopicPartition(topic1, 0)));
             probe.Request(1).ExpectError().Should().BeOfType<KafkaException>();
         }
 
@@ -176,7 +178,7 @@ namespace Akka.Streams.Kafka.Tests.Integration
             await Produce(topic1, Enumerable.Range(1, elementsCount), ProducerSettings);
 
             var settings = ConsumerSettings<Null, int>.Create(Sys, null, Deserializers.Int32)
-                .WithBootstrapServers(KafkaUrl)
+                .WithBootstrapServers(_fixture.KafkaServer)
                 .WithProperty("auto.offset.reset", "earliest")
                 .WithGroupId(group1);
 
@@ -206,7 +208,7 @@ namespace Akka.Streams.Kafka.Tests.Integration
             await Produce(topic1, Enumerable.Range(1, elementsCount), ProducerSettings);
 
             var settings = ConsumerSettings<Null, int>.Create(Sys, null, Deserializers.Int32)
-                .WithBootstrapServers(KafkaUrl)
+                .WithBootstrapServers(_fixture.KafkaServer)
                 .WithProperty("auto.offset.reset", "earliest")
                 .WithGroupId(group1);
 

--- a/src/Akka.Streams.Kafka.Tests/Integration/PlainSourceIntegrationTests.cs
+++ b/src/Akka.Streams.Kafka.Tests/Integration/PlainSourceIntegrationTests.cs
@@ -9,6 +9,7 @@ using Akka.Streams.Dsl;
 using Akka.Streams.Kafka.Dsl;
 using Akka.Streams.Kafka.Messages;
 using Akka.Streams.Kafka.Settings;
+using Akka.Streams.Kafka.Tests.Logging;
 using Akka.Streams.Supervision;
 using Akka.Streams.TestKit;
 using Confluent.Kafka;
@@ -19,8 +20,7 @@ using Config = Akka.Configuration.Config;
 
 namespace Akka.Streams.Kafka.Tests.Integration
 {
-    [Collection(KafkaSpecsFixture.Name)]
-    public class PlainSourceIntegrationTests : Akka.TestKit.Xunit2.TestKit
+    public class PlainSourceIntegrationTests : KafkaIntegrationTests
     {
         private const string InitialMsg = "initial msg in topic, required to create the topic before any consumer subscribes to it";
         
@@ -28,17 +28,10 @@ namespace Akka.Streams.Kafka.Tests.Integration
         private readonly ActorMaterializer _materializer;
 
         public PlainSourceIntegrationTests(ITestOutputHelper output, KafkaFixture fixture) 
-            : base(Default(), nameof(PlainSourceIntegrationTests), output)
+            : base(nameof(PlainSourceIntegrationTests), output)
         {
             _fixture = fixture;
             _materializer = Sys.Materializer();
-        }
-
-        private static Config Default()
-        {
-            var defaultSettings = ConfigurationFactory.FromResource<ConsumerSettings<object, object>>("Akka.Streams.Kafka.reference.conf");
-            
-            return ConfigurationFactory.ParseString("akka.loglevel = DEBUG").WithFallback(defaultSettings);
         }
 
         private string Uuid { get; } = Guid.NewGuid().ToString();

--- a/src/Akka.Streams.Kafka.Tests/KafkaFixture.cs
+++ b/src/Akka.Streams.Kafka.Tests/KafkaFixture.cs
@@ -1,0 +1,165 @@
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using Akka.Util;
+using Docker.DotNet;
+using Docker.DotNet.Models;
+using Xunit;
+
+namespace Akka.Streams.Kafka.Tests
+{
+    [CollectionDefinition(Name)]
+    public sealed class KafkaSpecsFixture : ICollectionFixture<KafkaFixture>
+    {
+        public const string Name = "KafkaSpecs";
+    }
+    
+    public class KafkaFixture : IAsyncLifetime
+    {
+        private const string KafkaImageName = "confluentinc/cp-kafka";
+        private const string KafkaImageTag = "latest";
+        private const string ZookeeperImageName = "confluentinc/cp-zookeeper";
+        private const string ZookeeperImageTag = "latest";
+        
+        private readonly string _kafkaContainerName = $"kafka-{Guid.NewGuid():N}";
+        private readonly string _zookeeperContainerName = $"zookeeper-{Guid.NewGuid():N}";
+        private readonly string _networkName = $"network-{Guid.NewGuid():N}";
+        
+        private readonly DockerClient _client;
+        
+        public KafkaFixture()
+        {
+            DockerClientConfiguration config;
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                config = new DockerClientConfiguration(new Uri("unix://var/run/docker.sock"));
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                config = new DockerClientConfiguration(new Uri("npipe://./pipe/docker_engine"));
+            else
+                throw new NotSupportedException($"Unsupported OS [{RuntimeInformation.OSDescription}]");
+
+            _client = config.CreateClient();
+        }
+        
+        public int KafkaPort { get; private set; }
+        public string KafkaServer => $"localhost:{KafkaPort}";
+
+        public async Task InitializeAsync()
+        {
+            // Load images, if they not exist yet
+            await EnsureImageExists(ZookeeperImageName, ZookeeperImageTag);
+            await EnsureImageExists(KafkaImageName, KafkaImageTag);
+
+            // Generate random ports for zookeeper and kafka
+            var zookeeperPort = ThreadLocalRandom.Current.Next(32000, 33000);
+            KafkaPort = ThreadLocalRandom.Current.Next(28000, 29000);
+
+            // create the containers
+            await CreateContainer(ZookeeperImageName, ZookeeperImageTag, _zookeeperContainerName, zookeeperPort, new Dictionary<string, string>()
+            {
+                ["ZOOKEEPER_CLIENT_PORT"] = zookeeperPort.ToString(),
+                ["ZOOKEEPER_TICK_TIME"] = "2000",
+            });
+            await CreateContainer(KafkaImageName, KafkaImageTag, _kafkaContainerName, KafkaPort, new Dictionary<string, string>()
+            {
+                ["KAFKA_BROKER_ID"] = "1",
+                ["KAFKA_ZOOKEEPER_CONNECT"] = $"{_zookeeperContainerName}:{zookeeperPort}", // referencing zookeeper container directly in common docker network
+                ["KAFKA_ADVERTISED_LISTENERS"] = $"PLAINTEXT://localhost:{KafkaPort}",
+                ["KAFKA_AUTO_CREATE_TOPICS_ENABLE"] = "true",
+                ["KAFKA_DELETE_TOPIC_ENABLE"] = "true",
+                ["KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR"] = "1"
+            });
+
+            // Setting up network for containers to communicate
+            var network = await _client.Networks.CreateNetworkAsync(new NetworksCreateParameters(new NetworkCreate())
+            {
+                Name = _networkName
+            });
+            await _client.Networks.ConnectNetworkAsync(network.ID, new NetworkConnectParameters()
+            {
+                Container = _kafkaContainerName
+            });
+            await _client.Networks.ConnectNetworkAsync(network.ID, new NetworkConnectParameters()
+            {
+                Container = _zookeeperContainerName
+            });
+
+            // start the containers
+            await _client.Containers.StartContainerAsync(_zookeeperContainerName, new ContainerStartParameters());
+            await _client.Containers.StartContainerAsync(_kafkaContainerName, new ContainerStartParameters());
+
+            // Provide a 10 second startup delay
+            await Task.Delay(TimeSpan.FromSeconds(10));
+        }
+
+        public async Task DisposeAsync()
+        {
+            if (_client != null)
+            {
+                // Stop Kafka
+                await _client.Containers.StopContainerAsync(_kafkaContainerName, new ContainerStopParameters());
+                await _client.Containers.RemoveContainerAsync(_kafkaContainerName, new ContainerRemoveParameters { Force = true });
+                
+                // Stop Zookeeper
+                await _client.Containers.StopContainerAsync(_zookeeperContainerName, new ContainerStopParameters());
+                await _client.Containers.RemoveContainerAsync(_zookeeperContainerName, new ContainerRemoveParameters { Force = true });
+
+                // Delete network between containers
+                await _client.Networks.DeleteNetworkAsync(_networkName);
+                
+                _client.Dispose();
+            }
+        }
+        
+        private async Task CreateContainer(string imageName, string imageTag, string containerName, int portToExpose, Dictionary<string, string> env)
+        {
+            await _client.Containers.CreateContainerAsync(new CreateContainerParameters
+            {
+                Image = $"{imageName}:{imageTag}",
+                Name = containerName,
+                Tty = true,
+                
+                ExposedPorts = new Dictionary<string, EmptyStruct>
+                {
+                    {$"{portToExpose}/tcp", new EmptyStruct()}
+                },
+                HostConfig = new HostConfig
+                {
+                    PortBindings = new Dictionary<string, IList<PortBinding>>
+                    {
+                        {
+                            $"{portToExpose}/tcp",
+                            new List<PortBinding>
+                            {
+                                new PortBinding
+                                {
+                                    HostPort = $"{portToExpose}"
+                                }
+                            }
+                        }
+                    },
+                    ExtraHosts = new [] { "moby:127.0.0.1", "localhost:127.0.0.1" },
+                },
+                Env = env.Select(pair => $"{pair.Key}={pair.Value}").ToArray(),
+            });
+        }
+
+        private async Task EnsureImageExists(string imageName, string imageTag)
+        {
+            var existingImages = await _client.Images.ListImagesAsync(new ImagesListParameters { MatchName = $"{imageName}:{imageTag}" });
+            if (existingImages.Count == 0)
+            {
+                await _client.Images.CreateImageAsync(
+                    new ImagesCreateParameters { FromImage = imageName, Tag = imageTag }, null,
+                    new Progress<JSONMessage>(message =>
+                    {
+                        Console.WriteLine(!string.IsNullOrEmpty(message.ErrorMessage)
+                            ? message.ErrorMessage
+                            : $"{message.ID} {message.Status} {message.ProgressMessage}");
+                    }));
+            }
+        }
+    }
+}

--- a/src/Akka.Streams.Kafka.Tests/KafkaIntegrationTests.cs
+++ b/src/Akka.Streams.Kafka.Tests/KafkaIntegrationTests.cs
@@ -1,3 +1,4 @@
+using System;
 using Akka.Configuration;
 using Akka.Streams.Kafka.Settings;
 using Xunit;
@@ -11,7 +12,7 @@ namespace Akka.Streams.Kafka.Tests
         /// <summary>
         /// Allows to write logs to file (useful for debugging when tests are running forever and no output in console is available)
         /// </summary>
-        private const bool UseFileLogging = true;
+        private static readonly bool UseFileLogging = Environment.GetEnvironmentVariable("AKKA_STREAMS_KAFKA_FILE_LOGGING") != null;
         
         public KafkaIntegrationTests(string actorSystemName, ITestOutputHelper output) 
             : base(Default(), actorSystemName, output)

--- a/src/Akka.Streams.Kafka.Tests/KafkaIntegrationTests.cs
+++ b/src/Akka.Streams.Kafka.Tests/KafkaIntegrationTests.cs
@@ -1,0 +1,38 @@
+using Akka.Configuration;
+using Akka.Streams.Kafka.Settings;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Akka.Streams.Kafka.Tests
+{
+    [Collection(KafkaSpecsFixture.Name)]
+    public class KafkaIntegrationTests : Akka.TestKit.Xunit2.TestKit
+    {
+        /// <summary>
+        /// Allows to write logs to file (useful for debugging when tests are running forever and no output in console is available)
+        /// </summary>
+        private const bool UseFileLogging = true;
+        
+        public KafkaIntegrationTests(string actorSystemName, ITestOutputHelper output) 
+            : base(Default(), actorSystemName, output)
+        {
+            Sys.Log.Info("Starting test: " + output.GetCurrentTestName());
+        }
+
+        private static Config Default()
+        {
+            var defaultSettings =
+                ConfigurationFactory.FromResource<ConsumerSettings<object, object>>("Akka.Streams.Kafka.reference.conf");
+            
+            var config = ConfigurationFactory.ParseString("akka.loglevel = DEBUG");
+
+            if (UseFileLogging)
+            {
+                config = config.WithFallback(
+                    ConfigurationFactory.ParseString("akka.loggers = [\"Akka.Streams.Kafka.Tests.Logging.SimpleFileLoggerActor, Akka.Streams.Kafka.Tests\"]"));
+            }
+            
+            return config.WithFallback(defaultSettings);
+        }
+    }
+}

--- a/src/Akka.Streams.Kafka.Tests/Logging/SimpleFileLoggerActor.cs
+++ b/src/Akka.Streams.Kafka.Tests/Logging/SimpleFileLoggerActor.cs
@@ -1,0 +1,31 @@
+using System;
+using System.IO;
+using Akka.Actor;
+using Akka.Event;
+
+namespace Akka.Streams.Kafka.Tests.Logging
+{
+    public class SimpleFileLoggerActor : ReceiveActor
+    {
+        public readonly string LogPath = $"logs\\{DateTime.Now:yyyy-MM-dd_HH-mm-ss}_{Guid.NewGuid():N}.txt";
+        
+        public SimpleFileLoggerActor()
+        {
+            Receive<Debug>(e => this.Log(LogLevel.DebugLevel, e.ToString()));
+            Receive<Info>(e => this.Log(LogLevel.InfoLevel, e.ToString()));
+            Receive<Warning>(e => this.Log(LogLevel.WarningLevel, e.ToString()));
+            Receive<Error>(e => this.Log(LogLevel.ErrorLevel, e.ToString()));
+            Receive<InitializeLogger>(_ =>
+            {
+                Sender.Tell(new LoggerInitialized());
+            });
+        }
+
+        private void Log(LogLevel level, string str)
+        {
+            var fullPath = Path.GetFullPath(LogPath);
+            Directory.CreateDirectory(Path.GetDirectoryName(fullPath));
+            File.AppendAllText(fullPath, $"{str}\r\n");
+        }
+    }
+}

--- a/src/Akka.Streams.Kafka/Stages/CommittableConsumerStage.cs
+++ b/src/Akka.Streams.Kafka/Stages/CommittableConsumerStage.cs
@@ -115,6 +115,7 @@ namespace Akka.Streams.Kafka.Stages
         {
             Log.Debug($"Consumer stopped: {_consumer.Name}");
             _consumer.Dispose();
+            _completion.SetResult(NotUsed.Instance);
 
             base.PostStop();
         }
@@ -186,7 +187,6 @@ namespace Akka.Streams.Kafka.Stages
                     case Directive.Stop:
                         // Throw
                         _completion.TrySetException(exception);
-                        _cancellationTokenSource.Cancel();
                         FailStage(exception);
                         break;
                     case Directive.Resume:

--- a/src/Akka.Streams.Kafka/Stages/ConsumerStage.cs
+++ b/src/Akka.Streams.Kafka/Stages/ConsumerStage.cs
@@ -7,6 +7,7 @@ using Akka.Streams.Stage;
 using Confluent.Kafka;
 using Akka.Streams.Supervision;
 using System.Runtime.Serialization;
+using System.Threading;
 
 namespace Akka.Streams.Kafka.Stages
 {
@@ -33,51 +34,50 @@ namespace Akka.Streams.Kafka.Stages
         }
     }
 
-    internal class KafkaSourceStageLogic<K, V> : TimerGraphStageLogic
+    internal class KafkaSourceStageLogic<K, V> : GraphStageLogic
     {
         private readonly ConsumerSettings<K, V> _settings;
         private readonly ISubscription _subscription;
-        private readonly Outlet<ConsumeResult<K, V>> _out;
         private IConsumer<K, V> _consumer;
 
-        private Action<ConsumeResult<K, V>> _messagesReceived;
         private Action<IEnumerable<TopicPartition>> _partitionsAssigned;
         private Action<IEnumerable<TopicPartitionOffset>> _partitionsRevoked;
         private readonly Decider _decider;
 
-        private const string TimerKey = "PollTimer";
-
-        private readonly Queue<ConsumeResult<K, V>> _buffer;
         private IEnumerable<TopicPartition> _assignedPartitions;
-        private volatile bool _isPaused;
         private readonly TaskCompletionSource<NotUsed> _completion;
+        private readonly CancellationTokenSource _cancellationTokenSource;
 
         public KafkaSourceStageLogic(KafkaSourceStage<K, V> stage, Attributes attributes, TaskCompletionSource<NotUsed> completion) : base(stage.Shape)
         {
             _settings = stage.Settings;
             _subscription = stage.Subscription;
-            _out = stage.Out;
             _completion = completion;
-            _buffer = new Queue<ConsumeResult<K, V>>(stage.Settings.BufferSize);
+            _cancellationTokenSource = new CancellationTokenSource();
 
             var supervisionStrategy = attributes.GetAttribute<ActorAttributes.SupervisionStrategy>(null);
             _decider = supervisionStrategy != null ? supervisionStrategy.Decider : Deciders.ResumingDecider;
 
-            SetHandler(_out, onPull: () =>
+            SetHandler(stage.Out, onPull: () =>
             {
-                if (_buffer.Count > 0)
+                try
                 {
-                    Push(_out, _buffer.Dequeue());
-                }
-                else
-                {
-                    if (_isPaused)
+                    var message = _consumer.Consume(_cancellationTokenSource.Token);
+                    if (message == null) // No message received, or consume error occured
+                        return;
+
+                    if (IsAvailable(stage.Out))
                     {
-                        _consumer.Resume(_assignedPartitions);
-                        _isPaused = false;
-                        Log.Debug("Polling resumed, buffer is empty");
+                        Push(stage.Out, message);
                     }
-                    PullQueue();
+                }
+                catch (OperationCanceledException)
+                {
+                    // Consume was canceled, looks like we are shutting down the stage
+                }
+                catch (ConsumeException ex)
+                {
+                    HandleError(ex.Error);
                 }
             });
         }
@@ -102,10 +102,8 @@ namespace Akka.Streams.Kafka.Stages
                     break;
             }
 
-            _messagesReceived = GetAsyncCallback<ConsumeResult<K, V>>(MessagesReceived);
             _partitionsAssigned = GetAsyncCallback<IEnumerable<TopicPartition>>(PartitionsAssigned);
             _partitionsRevoked = GetAsyncCallback<IEnumerable<TopicPartitionOffset>>(PartitionsRevoked);
-            ScheduleRepeatedly(TimerKey, _settings.PollInterval);
         }
 
         public override void PostStop()
@@ -115,34 +113,34 @@ namespace Akka.Streams.Kafka.Stages
 
             base.PostStop();
         }
-        
-        protected override void OnTimer(object timerKey) => PullQueue();
 
         //
         // Consumer's events
         //
-
-        private void HandleMessage(ConsumeResult<K, V> message) => _messagesReceived(message);
-        
-        private void MessagesReceived(ConsumeResult<K, V> message)
-        {
-            _buffer.Enqueue(message);
-            if (IsAvailable(_out))
-            {
-                Push(_out, _buffer.Dequeue());
-            }
-        }
 
         private void HandlePartitionsAssigned(IConsumer<K, V> consumer, List<TopicPartition> list)
         {
             _partitionsAssigned(list);
         }
         
+        private void HandlePartitionsRevoked(IConsumer<K, V> consumer, List<TopicPartitionOffset> currentOffsets)
+        {
+            _partitionsRevoked(currentOffsets);
+        }
+        
         private void PartitionsAssigned(IEnumerable<TopicPartition> partitions)
         {
             Log.Debug($"Partitions were assigned: {_consumer.Name}");
-            _consumer.Assign(partitions);
-            _assignedPartitions = partitions;
+            var partitionsList = partitions.ToList();
+            _consumer.Assign(partitionsList);
+            _assignedPartitions = partitionsList;
+        }
+        
+        private void PartitionsRevoked(IEnumerable<TopicPartitionOffset> partitions)
+        {
+            Log.Debug($"Partitions were revoked: {_consumer.Name}");
+            _consumer.Unassign();
+            _assignedPartitions = null;
         }
         
         private void HandleConsumeError(IConsumer<K, V> consumer, Error error)
@@ -155,6 +153,7 @@ namespace Akka.Streams.Kafka.Stages
                 case Directive.Stop:
                     // Throw
                     _completion.TrySetException(exception);
+                    _cancellationTokenSource.Cancel();
                     FailStage(exception);
                     break;
                 case Directive.Resume:
@@ -163,41 +162,6 @@ namespace Akka.Streams.Kafka.Stages
                 case Directive.Restart:
                     // keep going
                     break;
-            }
-        }
-
-        private void HandlePartitionsRevoked(IConsumer<K, V> consumer, List<TopicPartitionOffset> currentOffsets)
-        {
-            _partitionsRevoked(currentOffsets);
-        }
-
-        private void PartitionsRevoked(IEnumerable<TopicPartitionOffset> partitions)
-        {
-            Log.Debug($"Partitions were revoked: {_consumer.Name}");
-            _consumer.Unassign();
-            _assignedPartitions = null;
-        }
-
-        private void PullQueue()
-        {
-            try
-            {
-                var message = _consumer.Consume(_settings.PollTimeout);
-                if (message == null) // Sone error occured, nothing to do here
-                    return;
-                
-                HandleMessage(message);
-            }
-            catch (ConsumeException ex)
-            {
-                HandleError(ex.Error);
-            }
-
-            if (!_isPaused && _buffer.Count > _settings.BufferSize)
-            {
-                Log.Debug($"Polling paused, buffer is full");
-                _consumer.Pause(_assignedPartitions);
-                _isPaused = true;
             }
         }
         
@@ -218,6 +182,7 @@ namespace Akka.Streams.Kafka.Stages
                     case Directive.Stop:
                         // Throw
                         _completion.TrySetException(exception);
+                        _cancellationTokenSource.Cancel();
                         FailStage(exception);
                         break;
                     case Directive.Resume:

--- a/src/Akka.Streams.Kafka/Stages/ConsumerStage.cs
+++ b/src/Akka.Streams.Kafka/Stages/ConsumerStage.cs
@@ -79,6 +79,9 @@ namespace Akka.Streams.Kafka.Stages
                 {
                     HandleError(ex.Error);
                 }
+            }, onDownstreamFinish: () =>
+            {
+                _completion.SetResult(NotUsed.Instance);
             });
         }
 
@@ -110,7 +113,6 @@ namespace Akka.Streams.Kafka.Stages
         {
             Log.Debug($"Consumer stopped: {_consumer.Name}");
             _consumer.Dispose();
-            _completion.SetResult(NotUsed.Instance);
 
             base.PostStop();
         }

--- a/src/Akka.Streams.Kafka/Stages/ConsumerStage.cs
+++ b/src/Akka.Streams.Kafka/Stages/ConsumerStage.cs
@@ -110,6 +110,7 @@ namespace Akka.Streams.Kafka.Stages
         {
             Log.Debug($"Consumer stopped: {_consumer.Name}");
             _consumer.Dispose();
+            _completion.SetResult(NotUsed.Instance);
 
             base.PostStop();
         }
@@ -182,7 +183,6 @@ namespace Akka.Streams.Kafka.Stages
                     case Directive.Stop:
                         // Throw
                         _completion.TrySetException(exception);
-                        _cancellationTokenSource.Cancel();
                         FailStage(exception);
                         break;
                     case Directive.Resume:


### PR DESCRIPTION
This PR actually contains two currently pending pull requests: #38 and #40 .

#38 moved tests to Docker.NET and basically makes CI process working
#40 Updates implementation to not use buffering and timers in consumer stages. But CI will not show this PR passing, because it is missing Docker.NET 

Also, even with #38 and #40 applied, one of tests was still failing sometimes. So, the goal of this PR is to make current implementation pass tests. This will allow us to safely move further with working (hence incomplete) test coverage.

To review this, please ignore commits before merges - they are from other PRs. The actual code to review here is pretty small, it fixes test to match alpakka implementation (as fixes race conditions as well), and sets KafkaConsumer source task as completed after stage was stopped.

This also can possibly close issue #39 , because I was creating it with this PR in mind:
Close #39 

P.S. Let me know if I should not create PRs based on other PRs until they are merged.

P.P.S. While tests are passing, sometimes locally I have a weird issue that tests are freezing in some point, and executing forever. This is not easy to reproduce, so will return to this if  the problem will remain until the end of milestone.