### PR TITLE
Removed useless docker hosts setup

### DIFF
--- a/src/Akka.Streams.Kafka.Tests/KafkaFixture.cs
+++ b/src/Akka.Streams.Kafka.Tests/KafkaFixture.cs
@@ -140,7 +140,7 @@ namespace Akka.Streams.Kafka.Tests
                             }
                         }
                     },
-                    ExtraHosts = new [] { "moby:127.0.0.1", "localhost:127.0.0.1" },
+                    ExtraHosts = new [] { "localhost:127.0.0.1" },
                 },
                 Env = env.Select(pair => $"{pair.Key}={pair.Value}").ToArray(),
             });


### PR DESCRIPTION
This is tiny PR to remove useless docker `moby:127.0.0.1` hosts entry