### PR TITLE
Fix hard-coded groupId value for CommittableConsumerSource

### DIFF
--- a/src/Akka.Streams.Kafka/Settings/ConsumerSettings.cs
+++ b/src/Akka.Streams.Kafka/Settings/ConsumerSettings.cs
@@ -68,7 +68,7 @@ namespace Akka.Streams.Kafka.Settings
 
         public ConsumerSettings<TKey, TValue> WithDispatcher(string dispatcherId) => Copy(dispatcherId: dispatcherId);
 
-        public string GroupId => Properties.ContainsKey("group.id") ? Properties["group.id"] : string.Empty;
+        public string GroupId => Properties.ContainsKey("group.id") ? Properties["group.id"] : null;
 
         private ConsumerSettings<TKey, TValue> Copy(
             IDeserializer<TKey> keyDeserializer = null,

--- a/src/Akka.Streams.Kafka/Settings/ConsumerSettings.cs
+++ b/src/Akka.Streams.Kafka/Settings/ConsumerSettings.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using Akka.Actor;
@@ -67,6 +67,8 @@ namespace Akka.Streams.Kafka.Settings
         public ConsumerSettings<TKey, TValue> WithPollTimeout(TimeSpan pollTimeout) => Copy(pollTimeout: pollTimeout);
 
         public ConsumerSettings<TKey, TValue> WithDispatcher(string dispatcherId) => Copy(dispatcherId: dispatcherId);
+
+        public string GroupId => Properties.ContainsKey("group.id") ? Properties["group.id"] : string.Empty;
 
         private ConsumerSettings<TKey, TValue> Copy(
             IDeserializer<TKey> keyDeserializer = null,

--- a/src/Akka.Streams.Kafka/Stages/CommittableConsumerStage.cs
+++ b/src/Akka.Streams.Kafka/Stages/CommittableConsumerStage.cs
@@ -68,7 +68,7 @@ namespace Akka.Streams.Kafka.Stages
                     var consumer = _consumer;
                     var commitableOffset = new CommitableOffset(
                         () => consumer.Commit(),
-                        new PartitionOffset("groupId", message.Topic, message.Partition, message.Offset));
+                        new PartitionOffset(_settings.GroupId, message.Topic, message.Partition, message.Offset));
 
                     if (IsAvailable(stage.Out))
                     {


### PR DESCRIPTION
This PR fixes hard-coded group id value in downstream messages from committable consumer source.