### PR TITLE
Base stage with consuming actor

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -6,5 +6,6 @@
   <packageSources>
     <clear />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="Akka.NET Nightly" value="https://www.myget.org/F/akkadotnet/api/v2" />
   </packageSources>
 </configuration>

--- a/src/Akka.Streams.Kafka/Akka.Streams.Kafka.csproj
+++ b/src/Akka.Streams.Kafka/Akka.Streams.Kafka.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyTitle>Akka.Streams.Kafka</AssemblyTitle>
     <Description>Apache Kafka adapter for Akka.NET Streams</Description>
-    <TargetFramework>netstandard1.6</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <VersionPrefix>0.5.0</VersionPrefix>
     <VersionSuffix>beta</VersionSuffix>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Akka.Streams" Version="$(AkkaVersion)" />
+    <PackageReference Include="Akka.Streams" Version="1.4.0-beta637012445454141588" />
     <PackageReference Include="Confluent.Kafka" Version="1.1.0" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />
   </ItemGroup>

--- a/src/Akka.Streams.Kafka/Extensions/CollectionExtensions.cs
+++ b/src/Akka.Streams.Kafka/Extensions/CollectionExtensions.cs
@@ -1,0 +1,34 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+
+namespace Akka.Streams.Kafka.Extensions
+{
+    public static class CollectionExtensions
+    {
+        /// <summary>
+        /// Joins elements of the collection with given separator to single string
+        /// </summary>
+        public static string JoinToString<T>(this IEnumerable<T> collection, string separator)
+        {
+            return string.Join(separator, collection);
+        }
+
+        /// <summary>
+        /// Converts dictionary to a list of tuples
+        /// </summary>
+        public static IEnumerable<(TKey, TValue)> ToTuples<TKey, TValue>(this IEnumerable<KeyValuePair<TKey, TValue>> dictionary)
+        {
+            return dictionary.Select(pair => (pair.Key, pair.Value));
+        }
+
+        /// <summary>
+        /// Checks if collection is empty
+        /// </summary>
+        public static bool IsEmpty<T>(this IEnumerable<T> collection)
+        {
+            return !collection.Any();
+        }
+    }
+}

--- a/src/Akka.Streams.Kafka/Extensions/ObjectExtensions.cs
+++ b/src/Akka.Streams.Kafka/Extensions/ObjectExtensions.cs
@@ -1,0 +1,15 @@
+using Newtonsoft.Json;
+
+namespace Akka.Streams.Kafka.Extensions
+{
+    public static class ObjectExtensions
+    {
+        /// <summary>
+        /// Returns object's json representation as string
+        /// </summary>
+        public static string ToJson(this object obj)
+        {
+            return JsonConvert.SerializeObject(obj);
+        }
+    }
+}

--- a/src/Akka.Streams.Kafka/Helpers/KafkaConsumerEventHandlers.cs
+++ b/src/Akka.Streams.Kafka/Helpers/KafkaConsumerEventHandlers.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Collections.Immutable;
+using Akka.Streams.Stage;
+using Confluent.Kafka;
+
+namespace Akka.Streams.Kafka.Helpers
+{
+    /// <summary>
+    /// This interface is used to pass callbacks when Kafka rebalances partitions between consumers,
+    /// or an kafka consumer is stopped
+    /// </summary>
+    public interface IConsumerEventHandler
+    {
+        /// <summary>
+        /// Called when consumer error occures
+        /// </summary>
+        void OnError(Error error);
+        
+        /// <summary>
+        /// Called when partitions are revoked
+        /// </summary>
+        void OnRevoke(IImmutableSet<TopicPartitionOffset> revokedTopicPartitions);
+
+        /// <summary>
+        /// Called when partitions are assigned
+        /// </summary>
+        /// <param name="assignedTopicPartitions"></param>
+        void OnAssign(IImmutableSet<TopicPartition> assignedTopicPartitions);
+    }
+
+    /// <summary>
+    /// Dummy handler which does nothing. Also <see cref="IConsumerEventHandler"/>
+    /// </summary>
+    internal class EmptyConsumerEventHandler : IConsumerEventHandler
+    {
+        /// <inheritdoc />
+        public void OnError(Error error)
+        {
+        }
+
+        /// <inheritdoc />
+        public void OnRevoke(IImmutableSet<TopicPartitionOffset> revokedTopicPartitions)
+        {
+        }
+
+        /// <inheritdoc />
+        public void OnAssign(IImmutableSet<TopicPartition> assignedTopicPartitions)
+        {
+        }
+    }
+
+    /// <summary>
+    /// Handler allowing to pass custom stage callbacks. Also <see cref="IConsumerEventHandler"/>
+    /// </summary>
+    internal class AsyncCallbacksConsumerEventHandler : IConsumerEventHandler
+    {
+        private readonly Action<Error> _errorCallback;
+        private readonly Action<IImmutableSet<TopicPartition>> _partitionAssignedCallback;
+        private readonly Action<IImmutableSet<TopicPartitionOffset>> _partitionRevokedCallback;
+
+        public AsyncCallbacksConsumerEventHandler(Action<Error> errorCallback,
+                                                  Action<IImmutableSet<TopicPartition>> partitionAssignedCallback,
+                                                  Action<IImmutableSet<TopicPartitionOffset>> partitionRevokedCallback)
+        {
+            _errorCallback = errorCallback;
+            _partitionAssignedCallback = partitionAssignedCallback;
+            _partitionRevokedCallback = partitionRevokedCallback;
+        }
+
+        /// <inheritdoc />
+        public void OnError(Error error)
+        {
+            _errorCallback(error);
+        }
+
+        /// <inheritdoc />
+        public void OnRevoke(IImmutableSet<TopicPartitionOffset> revokedTopicPartitions)
+        {
+            _partitionRevokedCallback(revokedTopicPartitions);
+        }
+
+        /// <inheritdoc />
+        public void OnAssign(IImmutableSet<TopicPartition> assignedTopicPartitions)
+        {
+            _partitionAssignedCallback(assignedTopicPartitions);
+        }
+    }
+}

--- a/src/Akka.Streams.Kafka/Messages/CommittableMessage.cs
+++ b/src/Akka.Streams.Kafka/Messages/CommittableMessage.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Threading.Tasks;
 using Akka.Streams.Kafka.Dsl;
 using Akka.Streams.Kafka.Stages.Consumers;
@@ -98,7 +99,7 @@ namespace Akka.Streams.Kafka.Messages
         /// </summary>
         public Task Commit()
         {
-            return _committer.Commit();
+            return _committer.Commit(new List<PartitionOffset>() { Offset }.ToImmutableList());
         }
     }
 

--- a/src/Akka.Streams.Kafka/Settings/ConsumerSettings.cs
+++ b/src/Akka.Streams.Kafka/Settings/ConsumerSettings.cs
@@ -24,6 +24,8 @@ namespace Akka.Streams.Kafka.Settings
                 valueDeserializer: valueDeserializer,
                 pollInterval: config.GetTimeSpan("poll-interval", TimeSpan.FromMilliseconds(50)),
                 pollTimeout: config.GetTimeSpan("poll-timeout", TimeSpan.FromMilliseconds(50)),
+                commitTimeout: config.GetTimeSpan("commit-timeout", TimeSpan.FromMilliseconds(50)),
+                stopTimeout: config.GetTimeSpan("stop-timeout", TimeSpan.FromMilliseconds(50)),
                 bufferSize: config.GetInt("buffer-size", 50),
                 dispatcherId: config.GetString("use-dispatcher", "akka.kafka.default-dispatcher"),
                 properties: ImmutableDictionary<string, string>.Empty);
@@ -35,16 +37,22 @@ namespace Akka.Streams.Kafka.Settings
         public IDeserializer<TValue> ValueDeserializer { get; }
         public TimeSpan PollInterval { get; }
         public TimeSpan PollTimeout { get; }
+        public TimeSpan CommitTimeout { get; }
+        public TimeSpan StopTimeout { get; }
         public int BufferSize { get; }
         public string DispatcherId { get; }
         public IImmutableDictionary<string, string> Properties { get; }
 
-        public ConsumerSettings(IDeserializer<TKey> keyDeserializer, IDeserializer<TValue> valueDeserializer, TimeSpan pollInterval, TimeSpan pollTimeout, int bufferSize, string dispatcherId, IImmutableDictionary<string, string> properties)
+        public ConsumerSettings(IDeserializer<TKey> keyDeserializer, IDeserializer<TValue> valueDeserializer, TimeSpan pollInterval, 
+                                TimeSpan pollTimeout, TimeSpan commitTimeout, TimeSpan stopTimeout, int bufferSize, 
+                                string dispatcherId, IImmutableDictionary<string, string> properties)
         {
             KeyDeserializer = keyDeserializer;
             ValueDeserializer = valueDeserializer;
             PollInterval = pollInterval;
             PollTimeout = pollTimeout;
+            StopTimeout = stopTimeout;
+            CommitTimeout = commitTimeout;
             BufferSize = bufferSize;
             DispatcherId = dispatcherId;
             Properties = properties;
@@ -65,6 +73,9 @@ namespace Akka.Streams.Kafka.Settings
         public ConsumerSettings<TKey, TValue> WithPollInterval(TimeSpan pollInterval) => Copy(pollInterval: pollInterval);
 
         public ConsumerSettings<TKey, TValue> WithPollTimeout(TimeSpan pollTimeout) => Copy(pollTimeout: pollTimeout);
+        
+        public ConsumerSettings<TKey, TValue> WithCommitTimeout(TimeSpan commitTimeout) => Copy(commitTimeout: commitTimeout);
+        public ConsumerSettings<TKey, TValue> WithStopTimeout(TimeSpan stopTimeout) => Copy(stopTimeout: stopTimeout);
 
         public ConsumerSettings<TKey, TValue> WithDispatcher(string dispatcherId) => Copy(dispatcherId: dispatcherId);
         
@@ -75,6 +86,8 @@ namespace Akka.Streams.Kafka.Settings
             IDeserializer<TValue> valueDeserializer = null,
             TimeSpan? pollInterval = null,
             TimeSpan? pollTimeout = null,
+            TimeSpan? commitTimeout = null,
+            TimeSpan? stopTimeout = null,
             int? bufferSize = null,
             string dispatcherId = null,
             IImmutableDictionary<string, string> properties = null) =>
@@ -83,6 +96,8 @@ namespace Akka.Streams.Kafka.Settings
                 valueDeserializer: valueDeserializer ?? this.ValueDeserializer,
                 pollInterval: pollInterval ?? this.PollInterval,
                 pollTimeout: pollTimeout ?? this.PollTimeout,
+                commitTimeout: commitTimeout ?? this.CommitTimeout,
+                stopTimeout: stopTimeout ?? this.StopTimeout,
                 bufferSize: bufferSize ?? this.BufferSize,
                 dispatcherId: dispatcherId ?? this.DispatcherId,
                 properties: properties ?? this.Properties);

--- a/src/Akka.Streams.Kafka/Stages/Consumers/Abstract/BaseSingleSourceLogic.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/Abstract/BaseSingleSourceLogic.cs
@@ -1,0 +1,159 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Dispatch;
+using Akka.Streams.Kafka.Settings;
+using Akka.Streams.Kafka.Stages.Consumers.Actors;
+using Akka.Streams.Kafka.Stages.Consumers.Exceptions;
+using Akka.Streams.Stage;
+using Akka.Util;
+using Akka.Util.Internal;
+using Confluent.Kafka;
+
+namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
+{
+    /// <summary>
+    /// Shared GraphStageLogic for <see cref="SingleSourceStageLogic{K,V,TMessage}"/> and <see cref="ExternalSingleSourceLogic"/>
+    /// </summary>
+    /// <typeparam name="K">Key type</typeparam>
+    /// <typeparam name="V">Value type</typeparam>
+    /// <typeparam name="TMessage">Message type</typeparam>
+    internal abstract class BaseSingleSourceLogic<K, V, TMessage> : GraphStageLogic
+    {
+        private readonly SourceShape<TMessage> _shape;
+        private readonly TaskCompletionSource<NotUsed> _completion;
+        private readonly IMessageBuilder<K, V, TMessage> _messageBuilder;
+        private int _requestId = 0;
+        private bool _requested = false;
+        private readonly ConcurrentQueue<ConsumeResult<K, V>> _buffer = new ConcurrentQueue<ConsumeResult<K, V>>();
+        protected IImmutableSet<TopicPartition> TopicPartitions { get; set; } = ImmutableHashSet.Create<TopicPartition>();
+        
+        protected StageActor SourceActor { get; private set; }
+        internal IActorRef ConsumerActor { get; private set; }
+        internal MessageDispatcher ExecutionContext => Materializer.ExecutionContext;
+        
+        protected BaseSingleSourceLogic(SourceShape<TMessage> shape, TaskCompletionSource<NotUsed> completion,
+                                        Func<BaseSingleSourceLogic<K, V, TMessage>, IMessageBuilder<K, V, TMessage>> messageBuilderFactory) 
+            : base(shape)
+        {
+            _shape = shape;
+            _completion = completion;
+            _messageBuilder = messageBuilderFactory(this);
+            
+            SetHandler(shape.Outlet, onPull: Pump, onDownstreamFinish: PerformShutdown);
+        }
+
+        public override void PreStart()
+        {
+            base.PreStart();
+            
+            SourceActor = GetStageActor(MessageHandling);
+            ConsumerActor = CreateConsumerActor();
+            SourceActor.Watch(ConsumerActor);
+            
+            ConfigureSubscription();
+        }
+
+        public override void PostStop()
+        {
+            OnShutdown();
+            
+            base.PostStop();
+        }
+
+        /// <summary>
+        /// Creates consumer actor
+        /// </summary>
+        protected abstract IActorRef CreateConsumerActor();
+
+        /// <summary>
+        /// This should configure consumer subscription on stage start
+        /// </summary>
+        protected abstract void ConfigureSubscription();
+
+        /// <summary>
+        /// This is called when stage downstream is finished
+        /// </summary>
+        protected abstract void PerformShutdown();
+
+        /// <summary>
+        /// Makes this logic task finished
+        /// </summary>
+        protected void OnShutdown()
+        {
+            _completion.SetResult(NotUsed.Instance);
+        }
+
+        /// <summary>
+        /// Configures manual subscription
+        /// </summary>
+        /// <param name="subscription"></param>
+        protected void ConfigureManualSubscription(IManualSubscription subscription)
+        {
+            switch (subscription)
+            {
+                case Assignment assignment:
+                    ConsumerActor.Tell(new KafkaConsumerActorMetadata.Internal.Assign(assignment.TopicPartitions), SourceActor.Ref);
+                    TopicPartitions = TopicPartitions.Union(assignment.TopicPartitions);
+                    break;
+                case AssignmentWithOffset assignmentWithOffset:
+                    ConsumerActor.Tell(new KafkaConsumerActorMetadata.Internal.AssignWithOffset(assignmentWithOffset.TopicPartitions), SourceActor.Ref);
+                    TopicPartitions = TopicPartitions.Union(assignmentWithOffset.TopicPartitions.Select(tp => tp.TopicPartition));
+                    break;
+            }
+        }
+
+        private void MessageHandling(Tuple<IActorRef, object> args)
+        {
+            switch (args.Item2)
+            {
+                case KafkaConsumerActorMetadata.Internal.Messages<K, V> msg:
+                    // might be more than one in flight when we assign/revoke tps
+                    if (msg.RequestId == _requestId)
+                        _requested = false;
+
+                    foreach (var consumerMessage in msg.MessagesList)
+                        _buffer.Enqueue(consumerMessage);
+                    
+                    Pump();
+                    
+                    break;
+                
+                case Status.Failure failure:
+                    FailStage(failure.Cause);
+                    break;
+                
+                case Terminated terminated:
+                    FailStage(new ConsumerFailed());
+                    break;
+            }
+        }
+
+        private void Pump()
+        {
+            if (IsAvailable(_shape.Outlet))
+            {
+                if (_buffer.TryDequeue(out var message))
+                {
+                    Push(_shape.Outlet, _messageBuilder.CreateMessage(message));
+                    Pump();
+                }
+                else if (!_requested && TopicPartitions.Count == 0)
+                {
+                    RequestMessages();
+                }
+            }
+        }
+
+        protected void RequestMessages()
+        {
+            _requested = true;
+            _requestId += 1;
+            Log.Debug($"Requesting messages, requestId: {_requestId}, partitions: {string.Join(", ", TopicPartitions)}");
+            ConsumerActor.Tell(new KafkaConsumerActorMetadata.Internal.RequestMessages(_requestId, TopicPartitions.ToImmutableHashSet()), SourceActor.Ref);
+        }
+    }
+}

--- a/src/Akka.Streams.Kafka/Stages/Consumers/Abstract/ExternalSingleSourceLogic.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/Abstract/ExternalSingleSourceLogic.cs
@@ -1,0 +1,7 @@
+namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
+{
+    public class ExternalSingleSourceLogic
+    {
+        // TODO
+    }
+}

--- a/src/Akka.Streams.Kafka/Stages/Consumers/Abstract/SingleSourceStageLogic.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/Abstract/SingleSourceStageLogic.cs
@@ -1,35 +1,44 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Runtime.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Streams.Implementation;
+using Akka.Streams.Kafka.Helpers;
 using Akka.Streams.Kafka.Settings;
+using Akka.Streams.Kafka.Stages.Consumers.Abstract;
+using Akka.Streams.Kafka.Stages.Consumers.Actors;
 using Akka.Streams.Stage;
 using Akka.Streams.Supervision;
+using Akka.Util.Internal;
 using Confluent.Kafka;
+using Decider = Akka.Streams.Supervision.Decider;
+using Directive = Akka.Streams.Supervision.Directive;
 
 namespace Akka.Streams.Kafka.Stages.Consumers
 {
-    internal class SingleSourceStageLogic<K, V, TMessage> : GraphStageLogic
+    internal class SingleSourceStageLogic<K, V, TMessage> : BaseSingleSourceLogic<K, V, TMessage>
     {
+        private readonly SourceShape<TMessage> _shape;
         private readonly ConsumerSettings<K, V> _settings;
         private readonly ISubscription _subscription;
-        private IConsumer<K, V> _consumer;
 
-        private Action<IEnumerable<TopicPartition>> _partitionsAssigned;
-        private Action<IEnumerable<TopicPartitionOffset>> _partitionsRevoked;
         private readonly Decider _decider;
+        private readonly int _actorNumber = KafkaConsumerActorMetadata.NextNumber();
 
-        private IEnumerable<TopicPartition> _assignedPartitions;
         private readonly TaskCompletionSource<NotUsed> _completion;
         private readonly CancellationTokenSource _cancellationTokenSource;
 
         public SingleSourceStageLogic(SourceShape<TMessage> shape, ConsumerSettings<K, V> settings, 
-            ISubscription subscription, Attributes attributes, 
-            TaskCompletionSource<NotUsed> completion, IMessageBuilder<K, V, TMessage> messageBuilder) 
-            : base(shape)
+                                      ISubscription subscription, Attributes attributes, 
+                                      TaskCompletionSource<NotUsed> completion, 
+                                      Func<BaseSingleSourceLogic<K, V, TMessage>, IMessageBuilder<K, V, TMessage>> messageBuilderFactory) 
+            : base(shape, completion, messageBuilderFactory)
         {
+            _shape = shape;
             _settings = settings;
             _subscription = subscription;
             _completion = completion;
@@ -37,96 +46,101 @@ namespace Akka.Streams.Kafka.Stages.Consumers
 
             var supervisionStrategy = attributes.GetAttribute<ActorAttributes.SupervisionStrategy>(null);
             _decider = supervisionStrategy != null ? supervisionStrategy.Decider : Deciders.ResumingDecider;
-
-            SetHandler(shape.Outlet, onPull: () =>
-            {
-                try
-                {
-                    var message = _consumer.Consume(_cancellationTokenSource.Token);
-                    if (message == null) // No message received, or consume error occured
-                        return;
-
-                    if (IsAvailable(shape.Outlet))
-                    {
-                        Push(shape.Outlet, messageBuilder.CreateMessage(message, _consumer));
-                    }
-                }
-                catch (OperationCanceledException)
-                {
-                    // Consume was canceled, looks like we are shutting down the stage
-                }
-                catch (ConsumeException ex)
-                {
-                    HandleError(ex.Error);
-                }
-            }, onDownstreamFinish: () =>
-            {
-                _completion.SetResult(NotUsed.Instance);
-            });
         }
 
-        public override void PreStart()
+        /// <inheritdoc />
+        protected override void ConfigureSubscription()
         {
-            base.PreStart();
-
-            _consumer = _settings.CreateKafkaConsumer(HandleConsumeError, HandlePartitionsAssigned, HandlePartitionsRevoked);
-            Log.Debug($"Consumer started: {_consumer.Name}");
-
             switch (_subscription)
             {
-                case TopicSubscription ts:
-                    _consumer.Subscribe(ts.Topics);
+                case TopicSubscription topicSubscription:
+                    ConsumerActor.Tell(new KafkaConsumerActorMetadata.Internal.Subscribe(topicSubscription.Topics), SourceActor.Ref);
                     break;
-                case Assignment a:
-                    _consumer.Assign(a.TopicPartitions);
+                case Assignment assignment:
+                    ConsumerActor.Tell(new KafkaConsumerActorMetadata.Internal.Assign(assignment.TopicPartitions), SourceActor.Ref);
                     break;
-                case AssignmentWithOffset awo:
-                    _consumer.Assign(awo.TopicPartitions);
+                case AssignmentWithOffset assignmentWithOffset:
+                    ConsumerActor.Tell(new KafkaConsumerActorMetadata.Internal.AssignWithOffset(assignmentWithOffset.TopicPartitions), SourceActor.Ref);
                     break;
+                case IManualSubscription manualSubscription:
+                    ConfigureManualSubscription(manualSubscription);
+                    break;
+                default:
+                    throw new NotSupportedException();
             }
+        }
 
-            _partitionsAssigned = GetAsyncCallback<IEnumerable<TopicPartition>>(PartitionsAssigned);
-            _partitionsRevoked = GetAsyncCallback<IEnumerable<TopicPartitionOffset>>(PartitionsRevoked);
+        /// <inheritdoc />
+        protected override IActorRef CreateConsumerActor()
+        {
+            var partitionsAssignedHandler = GetAsyncCallback<IEnumerable<TopicPartition>>(PartitionsAssigned);
+            var partitionsRevokedHandler = GetAsyncCallback<IEnumerable<TopicPartitionOffset>>(PartitionsRevoked);
+            var errorOccuredHandler = GetAsyncCallback<Error>(HandleConsumeError);
+
+            var eventHandler = new AsyncCallbacksConsumerEventHandler(errorOccuredHandler, partitionsAssignedHandler, partitionsRevokedHandler);
+            
+            if (!(Materializer is ActorMaterializer actorMaterializer))
+                throw new ArgumentException($"Expected {typeof(ActorMaterializer)} but got {Materializer.GetType()}");
+            
+            var extendedActorSystem = actorMaterializer.System.AsInstanceOf<ExtendedActorSystem>();
+            var actor = extendedActorSystem.SystemActorOf(KafkaConsumerActorMetadata.GetProps(SourceActor.Ref, _settings, eventHandler), 
+                                                          $"kafka-consumer-{_actorNumber}");
+            return actor;
         }
 
         public override void PostStop()
         {
-            Log.Debug($"Consumer stopped: {_consumer.Name}");
-            _consumer.Dispose();
+            ConsumerActor.Tell(new KafkaConsumerActorMetadata.Internal.Stop(), SourceActor.Ref);
 
             base.PostStop();
         }
 
-        //
-        // Consumer's events
-        //
+        protected override void PerformShutdown()
+        {
+            SetKeepGoing(true);
+            
+            if (!IsClosed(_shape.Outlet))
+                Complete(_shape.Outlet);
+            
+            SourceActor.Become(ShuttingDownReceive);
+            StopConsumerActor();
+        }
 
-        private void HandlePartitionsAssigned(IConsumer<K, V> consumer, List<TopicPartition> list)
+        private void ShuttingDownReceive(Tuple<IActorRef, object> args)
         {
-            _partitionsAssigned(list);
+            switch (args.Item2)
+            {
+                case Terminated terminated when terminated.ActorRef.Equals(ConsumerActor):
+                    OnShutdown();
+                    CompleteStage();
+                    break;
+                default:
+                    return;
+            }
         }
-        
-        private void HandlePartitionsRevoked(IConsumer<K, V> consumer, List<TopicPartitionOffset> currentOffsets)
+
+        protected void StopConsumerActor()
         {
-            _partitionsRevoked(currentOffsets);
+            Materializer.ScheduleOnce(_settings.StopTimeout, () =>
+            {
+                ConsumerActor.Tell(new KafkaConsumerActorMetadata.Internal.Stop(), SourceActor.Ref);
+            });
         }
-        
+
         private void PartitionsAssigned(IEnumerable<TopicPartition> partitions)
         {
-            Log.Debug($"Partitions were assigned: {_consumer.Name}");
-            var partitionsList = partitions.ToList();
-            _consumer.Assign(partitionsList);
-            _assignedPartitions = partitionsList;
+            TopicPartitions = partitions.ToImmutableHashSet();
+            Log.Debug($"Partitions were assigned: {string.Join(", ", TopicPartitions)}");
+            RequestMessages();
         }
         
         private void PartitionsRevoked(IEnumerable<TopicPartitionOffset> partitions)
         {
-            Log.Debug($"Partitions were revoked: {_consumer.Name}");
-            _consumer.Unassign();
-            _assignedPartitions = null;
+            TopicPartitions = TopicPartitions.Clear();
+            Log.Debug("Partitions were revoked");
         }
         
-        private void HandleConsumeError(IConsumer<K, V> consumer, Error error)
+        private void HandleConsumeError(Error error)
         {
             Log.Error(error.Reason);
             // var exception = new SerializationException(error.Reason);

--- a/src/Akka.Streams.Kafka/Stages/Consumers/Actors/KafkaConsumerActor.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/Actors/KafkaConsumerActor.cs
@@ -1,0 +1,22 @@
+using Akka.Actor;
+using Akka.Streams.Kafka.Helpers;
+using Akka.Streams.Kafka.Settings;
+
+namespace Akka.Streams.Kafka.Stages.Consumers.Actors
+{
+    internal class KafkaConsumerActor<K, V> : ActorBase
+    {
+        private readonly IActorRef _owner;
+        private readonly ConsumerSettings<K, V> _settings;
+        private readonly IConsumerEventHandler _consumerEventHandler;
+
+        public KafkaConsumerActor(IActorRef owner, ConsumerSettings<K, V> settings, IConsumerEventHandler consumerEventHandler)
+        {
+            _owner = owner;
+            _settings = settings;
+            _consumerEventHandler = consumerEventHandler;
+        }
+
+        protected override bool Receive(object message) => throw new System.NotImplementedException();
+    }
+}

--- a/src/Akka.Streams.Kafka/Stages/Consumers/Actors/KafkaConsumerActor.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/Actors/KafkaConsumerActor.cs
@@ -1,6 +1,17 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Runtime.Serialization;
 using Akka.Actor;
+using Akka.Event;
+using Akka.Streams.Kafka.Extensions;
 using Akka.Streams.Kafka.Helpers;
 using Akka.Streams.Kafka.Settings;
+using Akka.Streams.Kafka.Stages.Consumers.Exceptions;
+using Akka.Util.Internal;
+using Confluent.Kafka;
+using Newtonsoft.Json;
 
 namespace Akka.Streams.Kafka.Stages.Consumers.Actors
 {
@@ -9,14 +20,402 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
         private readonly IActorRef _owner;
         private readonly ConsumerSettings<K, V> _settings;
         private readonly IConsumerEventHandler _consumerEventHandler;
+        
+        private ICancelable _poolCancellation;
+        private Internal.Poll<K, V> _pollMessage;
+        private Internal.Poll<K, V> _delayedPollMessage;
+        
+        private IImmutableDictionary<IActorRef, KafkaConsumerActorMetadata.Internal.RequestMessages> _requests 
+            = ImmutableDictionary<IActorRef, KafkaConsumerActorMetadata.Internal.RequestMessages>.Empty;
+        private IImmutableSet<IActorRef> _requestors = ImmutableHashSet<IActorRef>.Empty;
+        private IConsumer<K, V> _consumer;
+        private readonly ILoggingAdapter _log;
+        private bool _stopInProgress = false;
+        private bool _delayedPoolInFlight = false;
+
+        /// <summary>
+        /// While `true`, committing is delayed.
+        /// Changed by `onPartitionsRevoked` and `onPartitionsAssigned` callbacks
+        /// </summary>
+        private bool _rebalanceInProgress = false;
+        /// <summary>
+        /// Keeps commit offsets during rebalances for later commit.
+        /// </summary>
+        private IImmutableSet<TopicPartitionOffset> _rebalanceCommitStash = ImmutableHashSet<TopicPartitionOffset>.Empty;
+        /// <summary>
+        /// Keeps commit senders that need a reply once stashed commits are made.
+        /// </summary>
+        private IImmutableList<IActorRef> _rebalanceCommitSenders = new ImmutableArray<IActorRef>();
 
         public KafkaConsumerActor(IActorRef owner, ConsumerSettings<K, V> settings, IConsumerEventHandler consumerEventHandler)
         {
             _owner = owner;
             _settings = settings;
             _consumerEventHandler = consumerEventHandler;
+            
+            _pollMessage = new Internal.Poll<K, V>(this, periodic: true);
+            _delayedPollMessage = new Internal.Poll<K, V>(this, periodic: false);
+            _log = Context.GetLogger();
         }
 
-        protected override bool Receive(object message) => throw new System.NotImplementedException();
+        protected override bool Receive(object message)
+        {
+            switch (message)
+            {
+                case KafkaConsumerActorMetadata.Internal.Assign assign:
+                {
+                    ScheduleFirstPoolTask();
+                    CheckOverlappingRequests("Assign", Sender, assign.TopicPartitions);
+                    var previousAssigned = _consumer.Assignment;
+                    _consumer.Assign(assign.TopicPartitions.Union(previousAssigned));
+                    // TODO: Add CommitRefreshing call
+                    return true;
+                }
+
+                case KafkaConsumerActorMetadata.Internal.AssignWithOffset assignWithOffset:
+                {
+                    ScheduleFirstPoolTask();
+                    IImmutableSet<TopicPartition> topicPartitions = assignWithOffset.TopicPartitionOffsets.Select(o => o.TopicPartition).ToImmutableHashSet();
+                    CheckOverlappingRequests("AssignWithOffset", Sender, topicPartitions);
+                    var previousAssigned = _consumer.Assignment;
+                    _consumer.Assign(topicPartitions.Union(previousAssigned));
+                    assignWithOffset.TopicPartitionOffsets.ForEach(offset =>
+                    {
+                        _consumer.Seek(offset);
+                    });
+                    // TODO: Add CommitRefreshing call
+                    return true;
+                }
+                    
+                case KafkaConsumerActorMetadata.Internal.Commit commit when _rebalanceInProgress:
+                    _rebalanceCommitStash = _rebalanceCommitStash.Union(commit.Offsets);
+                    _rebalanceCommitSenders = _rebalanceCommitSenders.Add(Sender);
+                    return true;
+                
+                case KafkaConsumerActorMetadata.Internal.Commit commit:
+                    // TODO: Add call to CommitRefreshing
+                    var replyTo = Sender;
+                    Commit(commit.Offsets, msg => replyTo.Tell(msg));
+                    break;
+                
+                case KafkaConsumerActorMetadata.Internal.Subscribe subscribe:
+                    HandleSubscription(subscribe);
+                    return true;
+                
+                case KafkaConsumerActorMetadata.Internal.RequestMessages requestMessages:
+                    Context.Watch(Sender);
+                    CheckOverlappingRequests("RequestMessages", Sender, requestMessages.Topics);
+                    _requests = _requests.SetItem(Sender, requestMessages);
+                    _requestors.Add(Sender);
+                    
+                    // When many requestors, e.g. many partitions with committablePartitionedSource the
+                    // performance is much by collecting more requests/commits before performing the poll.
+                    // That is done by sending a message to self, and thereby collect pending messages in mailbox.
+                    if (_requestors.Count == 1)
+                    {
+                        Poll();
+                    }
+                    else if (!_delayedPoolInFlight)
+                    {
+                        _delayedPoolInFlight = true;
+                        Self.Tell(_delayedPollMessage);
+                    }
+                    return true;
+                
+                case KafkaConsumerActorMetadata.Internal.Committed committed:
+                    // TODO: Add CommitRefreshing call
+                    return true;
+                
+                case KafkaConsumerActorMetadata.Internal.Stop stop:
+                    _log.Debug($"Received Stop from {Sender}, stopping");
+                    Context.Stop(Self);
+                    return true;
+                
+                case Terminated terminated:
+                    _requests.Remove(terminated.ActorRef);
+                    _requestors.Remove(terminated.ActorRef);
+                    return true;
+                
+                default:
+                    return false;
+            }
+
+            return false;
+        }
+
+        // This is not going to be used, because in original alpakka implementation
+        // commits are asynchronious and this state is used for waiting until they are finished.
+        // But in .NET Kafka driver commits are synchronious, so nothing to wait in separate state.
+        private bool Stopping(object message)
+        {
+            switch (message)
+            {
+                case Internal.Poll<K, V> poll:
+                    ReceivePoll(poll);
+                    return true;
+                
+                case KafkaConsumerActorMetadata.Internal.Stop stop: 
+                    return true;
+                
+                case Terminated terminated: 
+                    return true;
+
+                case object msg when msg is KafkaConsumerActorMetadata.Internal.RequestMessages ||
+                                     msg is KafkaConsumerActorMetadata.Internal.Commit:
+                {
+                    Sender.Tell(new Status.Failure(new StoppingException()));
+                    return true;
+                }
+                
+                case object msg when msg is KafkaConsumerActorMetadata.Internal.Assign ||
+                                     msg is KafkaConsumerActorMetadata.Internal.AssignWithOffset ||
+                                     msg is KafkaConsumerActorMetadata.Internal.Subscribe:
+                {
+                    _log.Warning($"Got unexpected message {msg.ToJson()} when KafkaConsumerActor is in stopping state");
+                    return true;
+                }
+                
+                default:
+                    return false;
+            }
+        }
+
+        protected override void PreStart()
+        {
+            base.PreStart();
+
+            try
+            {
+                _log.Debug($"Creating Kafka consumer with settings: {JsonConvert.SerializeObject(_settings)}");
+                _consumer = _settings.CreateKafkaConsumer(consumeErrorHandler: (c, e) => _consumerEventHandler.OnError(e), 
+                                                          partitionAssignedHandler: (c, tp) => _consumerEventHandler.OnAssign(tp.ToImmutableHashSet()), 
+                                                          partitionRevokedHandler: (c, tp) => _consumerEventHandler.OnRevoke(tp.ToImmutableHashSet()));
+            }
+            catch (Exception ex)
+            {
+                _owner?.Tell(new Status.Failure(ex));
+            }
+        }
+
+        protected override void PostStop()
+        {
+            // reply to outstanding requests is important if the actor is restarted
+            foreach (var (actorRef, request) in _requests.ToTuples())
+            {
+                var emptyMessages = new KafkaConsumerActorMetadata.Internal.Messages<K, V>(request.RequestId, ImmutableList<ConsumeResult<K, V>>.Empty);
+                actorRef.Tell(emptyMessages);
+            }
+            
+            _consumer.Dispose();
+            
+            base.PostStop();
+        }
+
+        private void HandleSubscription(KafkaConsumerActorMetadata.Internal.Subscribe subscriptionRequest)
+        {
+            try
+            {
+                _consumer.Subscribe(subscriptionRequest.Topics);
+                
+                ScheduleFirstPoolTask();
+            }
+            catch (Exception ex)
+            {
+                ProcessErrors(ex);
+            }
+        }
+
+        private void ScheduleFirstPoolTask()
+        {
+            if (_poolCancellation == null || _poolCancellation.IsCancellationRequested)
+                SchedulePoolTask();
+        }
+
+        private void SchedulePoolTask()
+        {
+            _poolCancellation?.Cancel(); // Stop existing scheduling, if any
+            
+            _poolCancellation = Context.System.Scheduler.ScheduleTellOnceCancelable(_settings.PollInterval, Self, _pollMessage, Self);
+        }
+
+        private void CheckOverlappingRequests(string updateType, IActorRef fromStage, IImmutableSet<TopicPartition> topics)
+        {
+            // check if same topics/partitions have already been requested by someone else,
+            // which is an indication that something is wrong, but it might be alright when assignments change.
+            foreach (var (actorRef, request) in _requests.ToTuples())
+            {
+                if (!actorRef.Equals(fromStage) && request.Topics.Any(topics.Contains))
+                {
+                    _log.Warning($"{updateType} from topic/partition {string.Join(", ", topics)} " +
+                                 $"already requested by other stage {string.Join(", ", request.Topics)}");
+                    actorRef.Tell(new KafkaConsumerActorMetadata.Internal.Messages<K, V>(request.RequestId, ImmutableList<ConsumeResult<K, V>>.Empty));
+                    _requests.Remove(actorRef);
+                }
+            }
+        }
+
+        private void ReceivePoll(Internal.Poll<K, V> poll)
+        {
+            if (poll.Target == this)
+            {
+               // TODO: Get refreshOffsets from CommitRefreshing and commit them
+               
+               Poll();
+               
+               if (poll.Periodic)
+                   SchedulePoolTask();
+               else
+                   _delayedPoolInFlight = false;
+            }
+            else
+            {
+                // Message was enqueued before a restart - can be ignored
+                _log.Debug("Ignoring Poll message with stale target ref");
+            }
+        }
+
+        private void Poll()
+        {
+            var currentAssignment = _consumer.Assignment;
+            var initialRebalanceInProcess = _rebalanceInProgress;
+
+            try
+            {
+                if (_requests.IsEmpty())
+                {
+                    // no outstanding requests so we don't expect any messages back, but we should anyway
+                    // drive the KafkaConsumer by polling
+                    _consumer.Pause(currentAssignment);
+                    var message = _consumer.Consume(TimeSpan.FromMilliseconds(1));
+                    if (message != null)
+                        throw new IllegalActorStateException("Got unexpected Kafka message");
+                }
+                else
+                {
+                    // resume partitions to fetch
+                    IImmutableSet<TopicPartition> partitionsToFetch =
+                        _requests.Values.SelectMany(v => v.Topics).ToImmutableHashSet();
+                    var resumeThese = currentAssignment.Where(partitionsToFetch.Contains).ToList();
+                    var pauseThese = currentAssignment.Except(resumeThese).ToList();
+                    _consumer.Pause(pauseThese);
+                    _consumer.Resume(resumeThese);
+                    ProcessResult(partitionsToFetch, _consumer.Consume(_settings.PollTimeout));
+                }
+            }
+            catch (SerializationException ex)
+            {
+                ProcessErrors(ex);
+            }
+            catch (Exception ex)
+            {
+                ProcessErrors(ex);
+                _log.Error(ex, "Exception when polling from consumer, stopping actor: {}", ex.ToString());
+                Context.Stop(Self);
+            }
+             
+            CheckRebalanceState(initialRebalanceInProcess);
+
+            if (_stopInProgress)
+            {
+                _log.Debug("Stopping");
+                Context.Stop(Self);
+            }
+        }
+
+        private void ProcessResult(IImmutableSet<TopicPartition> partitionsToFetch, ConsumeResult<K,V> consumedMessage)
+        {
+            if (consumedMessage == null)
+                return;
+
+            var fetchedTopicPartition = consumedMessage.TopicPartition;
+            if (!partitionsToFetch.Contains(fetchedTopicPartition))
+            {
+                throw  new ArgumentException($"Unexpected records polled. Expected one of {partitionsToFetch.JoinToString(", ")}," +
+                                             $"but consumed result is {consumedMessage.ToJson()}, consumer assignment: {_consumer.Assignment.ToJson()}");
+            }
+
+            foreach (var (stageActorRef, request) in _requests.ToTuples())
+            {
+                // If requestor is interested in consumed topic, send him consumed result
+                if (request.Topics.Contains(consumedMessage.TopicPartition))
+                {
+                    var messages = ImmutableList<ConsumeResult<K, V>>.Empty.Add(consumedMessage);
+                    stageActorRef.Tell(new KafkaConsumerActorMetadata.Internal.Messages<K, V>(request.RequestId, messages));
+                }
+            }
+        }
+        
+        private void ProcessErrors(Exception error)
+        {
+            var involvedStageActors = _requests.Keys.Append(_owner).ToImmutableHashSet();
+            _log.Debug($"Sending failure to {involvedStageActors.JoinToString(", ")}");
+            foreach (var actor in involvedStageActors)
+            {
+                actor.Tell(new Status.Failure(error));
+                _requests.Remove(actor);
+            }
+        }
+
+        private void Commit(IImmutableSet<TopicPartitionOffset> commitMap, Action<object> sendReply)
+        {
+            try
+            {
+                // TODO: Add call to CommitRefreshing
+
+                _consumer.Commit(commitMap);
+
+                // TODO: Add warning when commit takes more then 'commit-time-warning' consumer settings
+                
+                Self.Tell(new KafkaConsumerActorMetadata.Internal.Committed(commitMap));
+                sendReply(Akka.Done.Instance);
+            }
+            catch (Exception ex)
+            {
+                sendReply(new Status.Failure(ex));
+            }
+
+            // When many requestors, e.g. many partitions with committablePartitionedSource the
+            // performance is much by collecting more requests/commits before performing the poll.
+            // That is done by sending a message to self, and thereby collect pending messages in mailbox.
+            if (_requestors.Count == 1)
+            {
+                Poll();
+            }
+            else if (!_delayedPoolInFlight)
+            {
+                _delayedPoolInFlight = true;
+                Self.Tell(_delayedPollMessage);
+            }
+        }
+
+        /// <summary>
+        /// Detects state changes of <see cref="_rebalanceInProgress"/> and takes action on it.
+        /// </summary>
+        private void CheckRebalanceState(bool initialRebalanceInProgress)
+        {
+            if (initialRebalanceInProgress && !_rebalanceInProgress && _rebalanceCommitSenders.Any())
+            {
+                _log.Debug($"Comitting stash {string.Join(", ", _rebalanceCommitStash)} replying to {string.Join(", ", _rebalanceCommitSenders)}");
+                var replyTo = _rebalanceCommitSenders;
+                Commit(_rebalanceCommitStash, msg => replyTo.ForEach(actor => actor.Tell(msg)));
+                _rebalanceCommitStash = ImmutableHashSet<TopicPartitionOffset>.Empty;
+                _rebalanceCommitSenders = ImmutableList<IActorRef>.Empty;
+            }
+        }
+
+        class Internal
+        {
+            public class Poll<k, V>
+            {
+                public Poll(KafkaConsumerActor<K, V> target, bool periodic)
+                {
+                    Target = target;
+                    Periodic = periodic;
+                }
+
+                public KafkaConsumerActor<K, V> Target { get; }
+                public bool Periodic { get; }
+            }
+        }
     }
 }

--- a/src/Akka.Streams.Kafka/Stages/Consumers/Actors/KafkaConsumerActorMetadata.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/Actors/KafkaConsumerActorMetadata.cs
@@ -57,7 +57,7 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
             }
 
             /// <summary>
-            /// Used to send commit requests to <see cref="KafkaConsumerActor"/>
+            /// Used to send commit requests to <see cref="KafkaConsumerActor{K,V}"/>
             /// </summary>
             public class Commit
             {
@@ -65,7 +65,7 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
                 /// Commit
                 /// </summary>
                 /// <param name="offsets">List of offsets to commit</param>
-                public Commit(ImmutableList<TopicPartitionOffset> offsets)
+                public Commit(IImmutableSet<TopicPartitionOffset> offsets)
                 {
                     Offsets = offsets;
                 }
@@ -73,7 +73,27 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
                 /// <summary>
                 /// List of offsets to commit
                 /// </summary>
-                public ImmutableList<TopicPartitionOffset> Offsets { get; }
+                public IImmutableSet<TopicPartitionOffset> Offsets { get; }
+            }
+
+            /// <summary>
+            /// Committed
+            /// </summary>
+            public class Committed
+            {
+                /// <summary>
+                /// Commited message
+                /// </summary>
+                /// <param name="offsets">Collection of committed offsets</param>
+                public Committed(IImmutableSet<TopicPartitionOffset> offsets)
+                {
+                    Offsets = offsets;
+                }
+
+                /// <summary>
+                /// Committed offsets
+                /// </summary>
+                public IImmutableSet<TopicPartitionOffset> Offsets { get; }
             }
 
             /// <summary>

--- a/src/Akka.Streams.Kafka/Stages/Consumers/Actors/KafkaConsumerActorMetadata.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/Actors/KafkaConsumerActorMetadata.cs
@@ -1,0 +1,171 @@
+using System.Collections.Immutable;
+using System.Threading;
+using Akka.Actor;
+using Akka.Streams.Kafka.Helpers;
+using Akka.Streams.Kafka.Settings;
+using Confluent.Kafka;
+
+namespace Akka.Streams.Kafka.Stages.Consumers.Actors
+{
+    internal class KafkaConsumerActorMetadata
+    {
+        private static volatile int _number = 1;
+        /// <summary>
+        /// Gets next actor number in thread-safe way
+        /// </summary>
+        /// <returns></returns>
+        public static int NextNumber() => Interlocked.Increment(ref _number);
+        
+        /// <summary>
+        /// Gets actor props
+        /// </summary>
+        public static Props GetProps<K, V>(ConsumerSettings<K, V> settings, IConsumerEventHandler handler) => 
+            Props.Create(() => new KafkaConsumerActor<K, V>(ActorRefs.Nobody, settings, handler)).WithDispatcher(settings.DispatcherId);
+        
+        /// <summary>
+        /// Gets actor props
+        /// </summary>
+        public static Props GetProps<K, V>(IActorRef owner, ConsumerSettings<K, V> settings, IConsumerEventHandler handler) => 
+            Props.Create(() => new KafkaConsumerActor<K, V>(owner, settings, handler)).WithDispatcher(settings.DispatcherId);
+        
+        internal class Internal
+        {
+            /// <summary>
+            /// Messages
+            /// </summary>
+            public class Messages<K, V>
+            {
+                /// <summary>
+                /// Messages
+                /// </summary>
+                /// <param name="requestId">Request Id</param>
+                /// <param name="messagesList">List of consumed messages</param>
+               public Messages(int requestId, ImmutableList<ConsumeResult<K, V>> messagesList)
+                {
+                    RequestId = requestId;
+                    MessagesList = messagesList;
+                }
+
+                /// <summary>
+                /// Request Id
+                /// </summary>
+                public int RequestId { get; }
+                /// <summary>
+                /// List of consumed messages
+                /// </summary>
+                public ImmutableList<ConsumeResult<K, V>> MessagesList { get; }
+            }
+
+            /// <summary>
+            /// Used to send commit requests to <see cref="KafkaConsumerActor"/>
+            /// </summary>
+            public class Commit
+            {
+                /// <summary>
+                /// Commit
+                /// </summary>
+                /// <param name="offsets">List of offsets to commit</param>
+                public Commit(ImmutableList<TopicPartitionOffset> offsets)
+                {
+                    Offsets = offsets;
+                }
+
+                /// <summary>
+                /// List of offsets to commit
+                /// </summary>
+                public ImmutableList<TopicPartitionOffset> Offsets { get; }
+            }
+
+            /// <summary>
+            /// Used to request for kafka messages
+            /// </summary>
+            public class RequestMessages
+            {
+                /// <summary>
+                /// RequestMessages
+                /// </summary>
+                /// <param name="requestId">Request Id</param>
+                /// <param name="topics">List of topics to consume</param>
+                public RequestMessages(int requestId, ImmutableHashSet<TopicPartition> topics)
+                {
+                    RequestId = requestId;
+                    Topics = topics;
+                }
+
+                /// <summary>
+                /// Request Id
+                /// </summary>
+                public int RequestId { get; }
+                /// <summary>
+                /// List of topics to consume
+                /// </summary>
+                public ImmutableHashSet<TopicPartition> Topics { get; }
+            }
+
+            /// <summary>
+            /// Assign
+            /// </summary>
+            public class Assign
+            {
+                /// <summary>
+                /// Assign
+                /// </summary>
+                /// <param name="topicPartitions">Topic partitions</param>
+                public Assign(IImmutableSet<TopicPartition> topicPartitions)
+                {
+                    TopicPartitions = topicPartitions;
+                }
+
+                /// <summary>
+                /// Topic partitions
+                /// </summary>
+                public IImmutableSet<TopicPartition> TopicPartitions { get; }
+            }
+            
+            /// <summary>
+            /// AssignWithOffset
+            /// </summary>
+            public class AssignWithOffset
+            {
+                /// <summary>
+                /// AssignWithOffset
+                /// </summary>
+                /// <param name="topicPartitionOffsets">Topic partitions with offsets</param>
+                public AssignWithOffset(IImmutableSet<TopicPartitionOffset> topicPartitionOffsets)
+                {
+                    TopicPartitionOffsets = topicPartitionOffsets;
+                }
+
+                /// <summary>
+                /// Topic partitions
+                /// </summary>
+                public IImmutableSet<TopicPartitionOffset> TopicPartitionOffsets { get; }
+            }
+
+            /// <summary>
+            /// Subscribe
+            /// </summary>
+            public class Subscribe
+            {
+                /// <summary>
+                /// Subscribe
+                /// </summary>
+                public Subscribe(IImmutableSet<string> topics)
+                {
+                    Topics = topics;
+                }
+
+                /// <summary>
+                /// List of topics to subscribe
+                /// </summary>
+                public IImmutableSet<string> Topics { get; }
+            }
+            
+            
+            /// <summary>
+            /// Stops consuming actor
+            /// </summary>
+            public class Stop{ }
+        }
+    }
+}

--- a/src/Akka.Streams.Kafka/Stages/Consumers/Committers.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/Committers.cs
@@ -39,7 +39,7 @@ namespace Akka.Streams.Kafka.Stages.Consumers
 
         public Task Commit(ImmutableList<PartitionOffset> offsets)
         {
-            var topicPartitionOffsets = offsets.Select(offset => new TopicPartitionOffset(offset.Topic, offset.Partition, offset.Offset)).ToImmutableList();
+            var topicPartitionOffsets = offsets.Select(offset => new TopicPartitionOffset(offset.Topic, offset.Partition, offset.Offset)).ToImmutableHashSet();
 
             return _consumerActor.Ask(new KafkaConsumerActorMetadata.Internal.Commit(topicPartitionOffsets), _commitTimeout)
                 .ContinueWith(t =>

--- a/src/Akka.Streams.Kafka/Stages/Consumers/Committers.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/Committers.cs
@@ -1,5 +1,13 @@
+using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
 using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Dispatch;
+using Akka.Streams.Kafka.Messages;
+using Akka.Streams.Kafka.Stages.Consumers.Actors;
+using Akka.Streams.Kafka.Stages.Consumers.Exceptions;
 using Confluent.Kafka;
 
 namespace Akka.Streams.Kafka.Stages.Consumers
@@ -12,24 +20,41 @@ namespace Akka.Streams.Kafka.Stages.Consumers
         /// <summary>
         /// Commit all offsets (of different topics) belonging to the same stage
         /// </summary>
-        Task Commit();
+        Task Commit(ImmutableList<PartitionOffset> offsets);
     }
-
-    /// <summary>
-    /// This is a simple committer using kafka consumer directly (not using consumer actor, etc)
-    /// </summary>
-    internal class KafkaCommitter<K, V> : IInternalCommitter
+    
+    internal class KafkaAsyncConsumerCommitter : IInternalCommitter
     {
-        private readonly IConsumer<K, V> _consumer;
+        private readonly IActorRef _consumerActor;
+        private readonly TimeSpan _commitTimeout;
+        private readonly MessageDispatcher _executionContext;
 
-        public KafkaCommitter(IConsumer<K, V> consumer)
+        public KafkaAsyncConsumerCommitter(IActorRef consumerActor, TimeSpan commitTimeout, MessageDispatcher executionContext)
         {
-            _consumer = consumer;
+            _consumerActor = consumerActor;
+            _commitTimeout = commitTimeout;
+            _executionContext = executionContext;
         }
 
-        /// <summary>
-        /// Commit all offsets (of different topics) belonging to the same stage
-        /// </summary>
-        public Task Commit() => Task.FromResult(_consumer.Commit());
+
+        public Task Commit(ImmutableList<PartitionOffset> offsets)
+        {
+            var topicPartitionOffsets = offsets.Select(offset => new TopicPartitionOffset(offset.Topic, offset.Partition, offset.Offset)).ToImmutableList();
+
+            return _consumerActor.Ask(new KafkaConsumerActorMetadata.Internal.Commit(topicPartitionOffsets), _commitTimeout)
+                .ContinueWith(t =>
+                {
+                    if (t.Exception != null)
+                    {
+                        switch (t.Exception.InnerException)
+                        {
+                            case AskTimeoutException timeoutException:
+                                throw new CommitTimeoutException($"Kafka commit took longer than: {_commitTimeout}");
+                            default:
+                                throw t.Exception;
+                        }
+                    }
+                });
+        }
     }
 }

--- a/src/Akka.Streams.Kafka/Stages/Consumers/Concrete/CommittableSourceStage.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/Concrete/CommittableSourceStage.cs
@@ -45,8 +45,13 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Concrete
         /// <returns>Stage logic</returns>
         protected override GraphStageLogic Logic(SourceShape<CommittableMessage<K, V>> shape, TaskCompletionSource<NotUsed> completion, Attributes inheritedAttributes)
         { 
-            return new SingleSourceStageLogic<K, V, CommittableMessage<K, V>>(shape, Settings, Subscription, inheritedAttributes, 
-                                                                              completion, new CommittableSourceMessageBuilder<K, V>(Settings, _metadataFromMessage));
+            return new SingleSourceStageLogic<K, V, CommittableMessage<K, V>>(shape, Settings, Subscription, inheritedAttributes, completion, GetMessageBuilder);
+        }
+
+        private CommittableSourceMessageBuilder<K, V> GetMessageBuilder(BaseSingleSourceLogic<K, V, CommittableMessage<K, V>> logic)
+        {
+            var committer = new KafkaAsyncConsumerCommitter(logic.ConsumerActor, Settings.CommitTimeout, logic.ExecutionContext);
+            return new CommittableSourceMessageBuilder<K, V>(committer, Settings, _metadataFromMessage);
         }
     }
 }

--- a/src/Akka.Streams.Kafka/Stages/Consumers/Concrete/PlainSourceStage.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/Concrete/PlainSourceStage.cs
@@ -40,7 +40,7 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Concrete
         protected override GraphStageLogic Logic(SourceShape<ConsumeResult<K, V>> shape, TaskCompletionSource<NotUsed> completion, Attributes inheritedAttributes)
         {
             return new SingleSourceStageLogic<K, V, ConsumeResult<K, V>>(shape, Settings, Subscription, inheritedAttributes, 
-                                                                         completion, new PlainMessageBuilder<K, V>());
+                                                                         completion, _ => new PlainMessageBuilder<K, V>());
         }
     }
 }

--- a/src/Akka.Streams.Kafka/Stages/Consumers/Exceptions/CommitTimeoutException.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/Exceptions/CommitTimeoutException.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace Akka.Streams.Kafka.Stages.Consumers.Exceptions
+{
+    /// <summary>
+    /// Calls to <see cref="IInternalCommitter.Commit"/> will be failed with this exception if
+    /// Kafka doesn't respond within commit timeout
+    /// </summary>
+    public class CommitTimeoutException : TimeoutException
+    {
+        public CommitTimeoutException(string message) : base(message) { }
+    }
+}

--- a/src/Akka.Streams.Kafka/Stages/Consumers/Exceptions/ConsumerFailed.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/Exceptions/ConsumerFailed.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace Akka.Streams.Kafka.Stages.Consumers.Exceptions
+{
+    /// <summary>
+    /// Kafka consumer stages fail with this exception.
+    /// </summary>
+    public class ConsumerFailed : Exception
+    {
+        /// <summary>
+        /// ConsumerFailed
+        /// </summary>
+        public ConsumerFailed() : this("Consumer actor failed") { }
+        /// <summary>
+        /// ConsumerFailed
+        /// </summary>
+        /// <param name="message">Message</param>
+        public ConsumerFailed(string message) : base(message) { }
+    }
+}

--- a/src/Akka.Streams.Kafka/Stages/Consumers/Exceptions/StoppingException.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/Exceptions/StoppingException.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Akka.Streams.Kafka.Stages.Consumers.Exceptions
+{
+    /// <summary>
+    /// Thrown in response to commit/message request commands by consuming actor when in stopping state
+    /// </summary>
+    public class StoppingException : Exception
+    {
+        public StoppingException() : base("Kafka consumer is stopping") { }
+    }
+}

--- a/src/Akka.Streams.Kafka/Stages/Consumers/MessageBuilders.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/MessageBuilders.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using Akka.Actor;
+using Akka.Dispatch;
 using Akka.Streams.Kafka.Messages;
 using Akka.Streams.Kafka.Settings;
 using Akka.Streams.Kafka.Stages.Consumers.Concrete;
@@ -16,7 +18,7 @@ namespace Akka.Streams.Kafka.Stages.Consumers
         /// We pass consumer here, because there is no way to get consumer instance from
         /// some global configuration, like Alpakka does getting consumer actor ref
         /// </remarks>
-        TMessage CreateMessage(ConsumeResult<K, V> record, IConsumer<K, V> consumer);
+        TMessage CreateMessage(ConsumeResult<K, V> record);
     }
     
     /// <summary>
@@ -24,38 +26,42 @@ namespace Akka.Streams.Kafka.Stages.Consumers
     /// </summary>
     public class PlainMessageBuilder<K, V> : IMessageBuilder<K, V, ConsumeResult<K, V>>
     {
-        public ConsumeResult<K, V> CreateMessage(ConsumeResult<K, V> record, IConsumer<K, V> consumer) => record;
+        public ConsumeResult<K, V> CreateMessage(ConsumeResult<K, V> record) => record;
     }
     
     /// <summary>
     /// This base class used for different committable source message builders
     /// </summary>
-    public abstract class CommittableMessageBuilder<K, V> : IMessageBuilder<K, V, CommittableMessage<K, V>>
+    internal abstract class CommittableMessageBuilderBase<K, V> : IMessageBuilder<K, V, CommittableMessage<K, V>>
     {
+        public abstract IInternalCommitter Committer { get; }
         public abstract string GroupId { get; }
         public abstract string MetadataFromRecord(ConsumeResult<K, V> record);
 
-        public CommittableMessage<K, V> CreateMessage(ConsumeResult<K, V> record, IConsumer<K, V> consumer)
+        public CommittableMessage<K, V> CreateMessage(ConsumeResult<K, V> record)
         {
             var offset = new PartitionOffset(GroupId, record.Topic, record.Partition, record.Offset);
-            return new CommittableMessage<K, V>(record, new CommittableOffset(new KafkaCommitter<K, V>(consumer), offset, MetadataFromRecord(record)));
+            return new CommittableMessage<K, V>(record, new CommittableOffset(Committer, offset, MetadataFromRecord(record)));
         }
     }
 
     /// <summary>
-    /// Message builder used for <see cref="CommittableSourceStage{K,V}"/>
+    /// Message builder used by <see cref="CommittableSourceStage{K,V}"/>
     /// </summary>
-    public class CommittableSourceMessageBuilder<K, V> : CommittableMessageBuilder<K, V>
+    internal class CommittableSourceMessageBuilder<K, V> : CommittableMessageBuilderBase<K, V>
     {
+        private readonly IInternalCommitter _committer;
         private readonly ConsumerSettings<K, V> _settings;
         private readonly Func<ConsumeResult<K, V>, string> _metadataFromRecord;
 
-        public CommittableSourceMessageBuilder(ConsumerSettings<K, V> settings, Func<ConsumeResult<K, V>, string> metadataFromRecord)
+        public CommittableSourceMessageBuilder(IInternalCommitter committer, ConsumerSettings<K, V> settings, Func<ConsumeResult<K, V>, string> metadataFromRecord)
         {
+            _committer = committer;
             _settings = settings;
             _metadataFromRecord = metadataFromRecord;
         }
 
+        public override IInternalCommitter Committer => _committer;
         public override string GroupId => _settings.GroupId;
         public override string MetadataFromRecord(ConsumeResult<K, V> record) => _metadataFromRecord(record);
     }


### PR DESCRIPTION
This PR is related to issue #36 . 

To move on and add different types of stages for consumers, we need to add two more abstractions:
 
1. `BaseSingleSourceLogic` - this is a new subclass for `SingleSourceStageLogic`. While `SingleSourceStageLogic` still contains some configuration and callback handlers, new `BaseSingleSourceLogic` is used to handle messages consuming from consumer actor
2. `KafkaConsumerActor` - is an actor, that is used to manage kafka consumer client. Basically, it receives all subscriptions from stages, subscribes to all topics they are interested in, and consumes messages on demand, broadcasting them to requesters once consumed. Error handling is also performed in this actor, to stages now only responsible for handling error messages and handling them according to supervision strategy.

I am creating this PR as a job-in-progress draft - right know new implementation is failing all consuming tests. So I will fix it and then move to review.

Also, code changes are pretty big, so will try to put my notes here as a part of PR review to simplify code review.

