### PR TITLE
Added option to customize partition events by stage logic subclasses

### DIFF
--- a/src/Akka.Streams.Kafka/Helpers/PartitionEventHandler.cs
+++ b/src/Akka.Streams.Kafka/Helpers/PartitionEventHandler.cs
@@ -7,53 +7,59 @@ using Confluent.Kafka;
 namespace Akka.Streams.Kafka.Helpers
 {
     /// <summary>
-    /// This interface is used to pass callbacks when Kafka rebalances partitions between consumers,
-    /// or an kafka consumer is stopped
+    /// The API is new and may change in further releases.
+    ///
+    /// Allows to execute user code when Kafka rebalances partitions between consumers, or an Alpakka Kafka consumer is stopped.
+    /// Use with care: These callbacks are called synchronously on the same thread Kafka's `poll()` is called.
+    /// A warning will be logged if a callback takes longer than the configured `partition-handler-warning`.
+    ///
+    /// There is no point in calling `CommittableOffset`'s commit methods as their committing won't be executed as long as any of
+    /// the callbacks in this class are called.
     /// </summary>
     [ApiMayChange]
-    internal interface IPartitionEventHandler
+    internal interface IPartitionEventHandler<K, V>
     {
         /// <summary>
         /// Called when partitions are revoked
         /// </summary>
-        void OnRevoke(IImmutableSet<TopicPartitionOffset> revokedTopicPartitions);
+        void OnRevoke(IImmutableSet<TopicPartitionOffset> revokedTopicPartitions, RestrictedConsumer<K, V> consumer);
 
         /// <summary>
         /// Called when partitions are assigned
         /// </summary>
-        void OnAssign(IImmutableSet<TopicPartition> assignedTopicPartitions);
+        void OnAssign(IImmutableSet<TopicPartition> assignedTopicPartitions, RestrictedConsumer<K, V> consumer);
 
         /// <summary>
         /// Called when consuming is stopped
         /// </summary>
-        void OnStop(IImmutableSet<TopicPartition> topicPartitions);
+        void OnStop(IImmutableSet<TopicPartition> topicPartitions, RestrictedConsumer<K, V> consumer);
     }
 
     /// <summary>
-    /// Dummy handler which does nothing. Also <see cref="IPartitionEventHandler"/>
+    /// Dummy handler which does nothing. Also <see cref="IPartitionEventHandler{K,V}"/>
     /// </summary>
-    internal class EmptyPartitionEventHandler : IPartitionEventHandler
+    internal class EmptyPartitionEventHandler<K, V> : IPartitionEventHandler<K, V>
     {
         /// <inheritdoc />
-        public void OnRevoke(IImmutableSet<TopicPartitionOffset> revokedTopicPartitions)
+        public void OnRevoke(IImmutableSet<TopicPartitionOffset> revokedTopicPartitions, RestrictedConsumer<K, V> consumer)
         {
         }
 
         /// <inheritdoc />
-        public void OnAssign(IImmutableSet<TopicPartition> assignedTopicPartitions)
+        public void OnAssign(IImmutableSet<TopicPartition> assignedTopicPartitions, RestrictedConsumer<K, V> consumer)
         {
         }
 
         /// <inheritdoc />
-        public void OnStop(IImmutableSet<TopicPartition> topicPartitions)
+        public void OnStop(IImmutableSet<TopicPartition> topicPartitions, RestrictedConsumer<K, V> consumer)
         {
         }
     }
 
     /// <summary>
-    /// Handler allowing to pass custom stage callbacks. Also <see cref="IPartitionEventHandler"/>
+    /// Handler allowing to pass custom stage callbacks. Also <see cref="IPartitionEventHandler{K,V}"/>
     /// </summary>
-    internal class AsyncCallbacksPartitionEventHandler : IPartitionEventHandler
+    internal class AsyncCallbacksPartitionEventHandler<K, V> : IPartitionEventHandler<K, V>
     {
         private readonly Action<IImmutableSet<TopicPartition>> _partitionAssignedCallback;
         private readonly Action<IImmutableSet<TopicPartitionOffset>> _partitionRevokedCallback;
@@ -66,19 +72,19 @@ namespace Akka.Streams.Kafka.Helpers
         }
 
         /// <inheritdoc />
-        public void OnRevoke(IImmutableSet<TopicPartitionOffset> revokedTopicPartitions)
+        public void OnRevoke(IImmutableSet<TopicPartitionOffset> revokedTopicPartitions, RestrictedConsumer<K, V> consumer)
         {
             _partitionRevokedCallback(revokedTopicPartitions);
         }
 
         /// <inheritdoc />
-        public void OnAssign(IImmutableSet<TopicPartition> assignedTopicPartitions)
+        public void OnAssign(IImmutableSet<TopicPartition> assignedTopicPartitions, RestrictedConsumer<K, V> consumer)
         {
             _partitionAssignedCallback(assignedTopicPartitions);
         }
 
         /// <inheritdoc />
-        public void OnStop(IImmutableSet<TopicPartition> topicPartitions)
+        public void OnStop(IImmutableSet<TopicPartition> topicPartitions, RestrictedConsumer<K, V> consumer)
         {
         }
     }

--- a/src/Akka.Streams.Kafka/Stages/Consumers/Actors/KafkaConsumerActor.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/Actors/KafkaConsumerActor.cs
@@ -502,6 +502,7 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
 
                 var watch = Stopwatch.StartNew();
                 _partitionEventHandler.OnAssign(partitions, _restrictedConsumer);
+                watch.Stop();
                 CheckDuration(watch, "onAssign");
                 
                 _actor._rebalanceInProgress = false;
@@ -511,6 +512,7 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
             {
                 var watch = Stopwatch.StartNew();
                 _partitionEventHandler.OnRevoke(partitions, _restrictedConsumer);
+                watch.Stop();
                 CheckDuration(watch, "onRevoke");
                 
                 _actor._commitRefreshing.Revoke(partitions.Select(tp => tp.TopicPartition).ToImmutableHashSet());
@@ -524,12 +526,12 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
                 
                 var watch = Stopwatch.StartNew();
                 _partitionEventHandler.OnStop(currentTopicPartitions.ToImmutableHashSet(), _restrictedConsumer);
+                watch.Stop();
                 CheckDuration(watch, "onStop");
             }
 
             private void CheckDuration(Stopwatch watch, string method)
             {
-                watch.Stop();
                 if (watch.Elapsed > _warningDuration)
                 {
                     _actor._log.Warning("Partition assignment handler `{0}` took longer than `partition-handler-warning`: {1} ms", method, watch.ElapsedMilliseconds);

--- a/src/Akka.Streams.Kafka/Stages/Consumers/Actors/KafkaConsumerActorMetadata.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/Actors/KafkaConsumerActorMetadata.cs
@@ -19,13 +19,13 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
         /// <summary>
         /// Gets actor props
         /// </summary>
-        public static Props GetProps<K, V>(ConsumerSettings<K, V> settings, IPartitionEventHandler handler) => 
+        public static Props GetProps<K, V>(ConsumerSettings<K, V> settings, IPartitionEventHandler<K,V> handler) => 
             Props.Create(() => new KafkaConsumerActor<K, V>(ActorRefs.Nobody, settings, handler)).WithDispatcher(settings.DispatcherId);
         
         /// <summary>
         /// Gets actor props
         /// </summary>
-        public static Props GetProps<K, V>(IActorRef owner, ConsumerSettings<K, V> settings, IPartitionEventHandler handler) => 
+        public static Props GetProps<K, V>(IActorRef owner, ConsumerSettings<K, V> settings, IPartitionEventHandler<K,V> handler) => 
             Props.Create(() => new KafkaConsumerActor<K, V>(owner, settings, handler)).WithDispatcher(settings.DispatcherId);
         
         internal class Internal


### PR DESCRIPTION
This is a small PR, which adds a way to customize partition events handling by different stage logic classes.

Before this PR partitions events were handled by `SingleSourceStageLogic` without any option to override it. Besides, original kafka driver callbacks also provide `consumer` instance passed to callbacks, so actually handling could use some consumer's methods.

Now consumer is passed to this callbacks, and the callbacks itself may be customized by logic subclasses (looks like only for `TransactionalSourceLogic` so far).