### PR TITLE
Added option to reuse existing container

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,3 +118,27 @@ KafkaConsumer.CommitableSource(consumerSettings, Subscriptions.Topics("topic1"))
 The above example uses separate mapAsync stages for processing and committing. This guarantees that for parallelism higher than 1 we will keep correct ordering of messages sent for commit.
 
 Committing the offset for each message as illustrated above is rather slow. It is recommended to batch the commits for better throughput, with the trade-off that more messages may be re-delivered in case of failures.
+
+## Local development
+
+There are some helpers to simplify local development
+
+### Tests: File logging
+
+Sometimes it is useful to have all logs written to a file in addition to console. 
+
+There is a built-in file logger, that will be added to default Akka.NET loggers if you will set `AKKA_STREAMS_KAFKA_TEST_FILE_LOGGING` environment variable on your local system to any value.
+
+When set, all logs will be written to `logs` subfolder near to your test assembly, one file per test. Here is how log file name is generated:
+
+```C#
+public readonly string LogPath = $"logs\\{DateTime.Now:yyyy-MM-dd_HH-mm-ss}_{Guid.NewGuid():N}.txt";
+```
+
+### Tests: kafka container reuse
+
+By default, tests are configured to be friendly to CI - that is, before starting tests docker kafka images will be downloaded (if not yet exist) and containers started, and after all tests finish full cleanup will be performed (except the fact that downloaded docker images will not be removed).
+
+While this might be useful when running tests locally, there are situations when you would like to save startup/shutdown tests time by using some pre-existing container, that will be used for all test runs and will not be stopped/started each time.
+
+To achieve that, set `AKKA_STREAMS_KAFKA_TEST_CONTAINER_REUSE` environment variable on your local machine to any value. This will force using existing kafka container, listening on port `29092` . Use `docker-compose up` console command in the root of project folder to get this container up and running.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:4.0.0
+    image: confluentinc/cp-zookeeper:5.3.0
     ports:
      - 32181:32181
     environment:
@@ -13,7 +13,7 @@ services:
       - "localhost: 127.0.0.1"
 
   kafka:
-    image: confluentinc/cp-kafka:4.0.0
+    image: confluentinc/cp-kafka:5.3.0
     ports:
      - 29092:29092
     depends_on:

--- a/src/Akka.Streams.Kafka.Tests/KafkaIntegrationTests.cs
+++ b/src/Akka.Streams.Kafka.Tests/KafkaIntegrationTests.cs
@@ -9,11 +9,6 @@ namespace Akka.Streams.Kafka.Tests
     [Collection(KafkaSpecsFixture.Name)]
     public class KafkaIntegrationTests : Akka.TestKit.Xunit2.TestKit
     {
-        /// <summary>
-        /// Allows to write logs to file (useful for debugging when tests are running forever and no output in console is available)
-        /// </summary>
-        private static readonly bool UseFileLogging = Environment.GetEnvironmentVariable("AKKA_STREAMS_KAFKA_FILE_LOGGING") != null;
-        
         public KafkaIntegrationTests(string actorSystemName, ITestOutputHelper output) 
             : base(Default(), actorSystemName, output)
         {
@@ -27,7 +22,7 @@ namespace Akka.Streams.Kafka.Tests
             
             var config = ConfigurationFactory.ParseString("akka.loglevel = DEBUG");
 
-            if (UseFileLogging)
+            if (TestsConfiguration.UseFileLogging)
             {
                 config = config.WithFallback(
                     ConfigurationFactory.ParseString("akka.loggers = [\"Akka.Streams.Kafka.Tests.Logging.SimpleFileLoggerActor, Akka.Streams.Kafka.Tests\"]"));

--- a/src/Akka.Streams.Kafka.Tests/TestsConfiguration.cs
+++ b/src/Akka.Streams.Kafka.Tests/TestsConfiguration.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace Akka.Streams.Kafka.Tests
+{
+    /// <summary>
+    /// Stores info about testing configuration, obtained from environment
+    /// </summary>
+    public static class TestsConfiguration
+    {
+        /// <summary>
+        /// Allows to write logs to file (useful for debugging when tests are running forever and no output in console is available)
+        /// </summary>
+        public static readonly bool UseFileLogging = Environment.GetEnvironmentVariable("AKKA_STREAMS_KAFKA_TEST_FILE_LOGGING") != null;
+        
+        /// <summary>
+        /// Allows to avoid delays on tests startup/shutdown, related to new containers creation/stopping process 
+        /// </summary>
+        /// <remarks>
+        /// When this option is enabled, use docker-compose to start kafka manually (see docker-compose.yml file in the root folder)
+        /// </remarks>
+        public static readonly bool UseExistingDockerContainer = Environment.GetEnvironmentVariable("AKKA_STREAMS_KAFKA_TEST_CONTAINER_REUSE") != null;
+    }
+}


### PR DESCRIPTION
While starting new containers and performing resources cleanup after each tests run is useful for CI, this takes time during local development, when you need to start-stop same tests multiple time (for debugging, etc).

This small PR adds possibility to use `docker-compose up` from project root folder to start kafka container, and then reuse this container for all further test runs. 

It uses environment variables as a configuration source to avoid changing anything between local testing and pushing updates for CI.