### PR TITLE
Kafka consumer AtMostOnceSource

### DIFF
--- a/src/Akka.Streams.Kafka.Tests/Integration/AtMostOnceSourceIntegrationTests.cs
+++ b/src/Akka.Streams.Kafka.Tests/Integration/AtMostOnceSourceIntegrationTests.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Akka.Streams.Dsl;
+using Akka.Streams.Kafka.Dsl;
+using Akka.Streams.Kafka.Settings;
+using Akka.Streams.TestKit;
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Akka.Streams.Kafka.Tests.Integration
+{
+    public class AtMostOnceSourceIntegrationTests : KafkaIntegrationTests
+    {
+        public AtMostOnceSourceIntegrationTests(ITestOutputHelper output, KafkaFixture fixture) 
+            : base(nameof(AtMostOnceSourceIntegrationTests), output, fixture)
+        {
+        }
+
+        [Fact]
+        public async Task AtMostOnceSource_Should_stop_consuming_actor_when_used_with_Take()
+        {
+            var topic = CreateTopic(1);
+            var group = CreateGroup(1);
+
+            await ProduceStrings(topic, Enumerable.Range(1, 10), ProducerSettings);
+            
+            var (task, result) = KafkaConsumer.AtMostOnceSource(CreateConsumerSettings<string>(group), Subscriptions.Topics(topic))
+                .Select(m => m.Value)
+                .Take(5)
+                .ToMaterialized(Sink.Seq<string>(), Keep.Both)
+                .Run(Materializer);
+            
+            AwaitCondition(() => task.IsCompletedSuccessfully, TimeSpan.FromSeconds(10));
+            
+            result.Result.Should().BeEquivalentTo(Enumerable.Range(1, 5).Select(i => i.ToString()));
+        }
+
+        [Fact]
+        public async Task AtMostOnceSource_Should_work()
+        {
+            var topic = CreateTopic(1);
+            var settings = CreateConsumerSettings<string>(CreateGroup(1));
+            var totalMessages = 10;
+            var lastMessage = new TaskCompletionSource<Done>();
+
+            var (task, probe) = KafkaConsumer.AtMostOnceSource(settings, Subscriptions.Topics(topic))
+                .SelectAsync(1, m =>
+                {
+                    if (m.Value == totalMessages.ToString())
+                        lastMessage.SetResult(Done.Instance);
+
+                    return Task.FromResult(Done.Instance);
+                })
+                .ToMaterialized(this.SinkProbe<Done>(), Keep.Both)
+                .Run(Materializer);
+
+            await ProduceStrings(topic, Enumerable.Range(1, 10), ProducerSettings);
+
+            probe.Request(10);
+            
+            AwaitCondition(() => lastMessage.Task.IsCompletedSuccessfully, TimeSpan.FromSeconds(10));
+           
+            probe.Cancel();
+            
+            probe.ExpectNextN(10);
+        }
+    }
+}

--- a/src/Akka.Streams.Kafka.Tests/Integration/AtMostOnceSourceIntegrationTests.cs
+++ b/src/Akka.Streams.Kafka.Tests/Integration/AtMostOnceSourceIntegrationTests.cs
@@ -44,6 +44,8 @@ namespace Akka.Streams.Kafka.Tests.Integration
             var settings = CreateConsumerSettings<string>(CreateGroup(1));
             var totalMessages = 10;
             var lastMessage = new TaskCompletionSource<Done>();
+            
+            await ProduceStrings(topic, Enumerable.Range(1, 10), ProducerSettings);
 
             var (task, probe) = KafkaConsumer.AtMostOnceSource(settings, Subscriptions.Topics(topic))
                 .SelectAsync(1, m =>
@@ -55,8 +57,6 @@ namespace Akka.Streams.Kafka.Tests.Integration
                 })
                 .ToMaterialized(this.SinkProbe<Done>(), Keep.Both)
                 .Run(Materializer);
-
-            await ProduceStrings(topic, Enumerable.Range(1, 10), ProducerSettings);
 
             probe.Request(10);
             

--- a/src/Akka.Streams.Kafka.Tests/Integration/AtMostOnceSourceIntegrationTests.cs
+++ b/src/Akka.Streams.Kafka.Tests/Integration/AtMostOnceSourceIntegrationTests.cs
@@ -60,7 +60,7 @@ namespace Akka.Streams.Kafka.Tests.Integration
 
             probe.Request(10);
             
-            AwaitCondition(() => lastMessage.Task.IsCompletedSuccessfully, TimeSpan.FromSeconds(10));
+            AwaitCondition(() => lastMessage.Task.IsCompletedSuccessfully, TimeSpan.FromSeconds(15));
            
             probe.Cancel();
             

--- a/src/Akka.Streams.Kafka.Tests/KafkaIntegrationTests.cs
+++ b/src/Akka.Streams.Kafka.Tests/KafkaIntegrationTests.cs
@@ -16,7 +16,7 @@ using Config = Akka.Configuration.Config;
 namespace Akka.Streams.Kafka.Tests
 {
     [Collection(KafkaSpecsFixture.Name)]
-    public class KafkaIntegrationTests : Akka.TestKit.Xunit2.TestKit
+    public abstract class KafkaIntegrationTests : Akka.TestKit.Xunit2.TestKit
     {
         private readonly KafkaFixture _fixture;
         protected IMaterializer Materializer { get; }


### PR DESCRIPTION
This is really tiny PR as a part of work on issue #36, but may require some help.

Basically, `AtMostOnceSource` consuming source just commits all messages before passing them to downstream, that's why at-most-once delivery comes up.

But I am not completely sure I have translated this from scala to c# right.
Here is this how this code looks like in alpakka:
```scala
def atMostOnceSource[K, V](settings: ConsumerSettings[K, V],
                             subscription: Subscription): Source[ConsumerRecord[K, V], Control] =
    committableSource[K, V](settings, subscription).mapAsync(1) { m =>
      m.committableOffset.commitScaladsl().map(_ => m.record)(ExecutionContexts.sameThreadExecutionContext)
    }
```

My confusion is about `ExecutionContexts.sameThreadExecutionContext` option. Here is scala [docs](https://doc.akka.io/japi/akka/current/akka/dispatch/ExecutionContexts.sameThreadExecutionContext$.html) for it. Seems like this is a way to make task continuation execute on the same thread.

What I have used right now is:
```c#
return CommittableSource(settings, subscription).SelectAsync(1, async message =>
{
   await message.CommitableOffset.Commit();
   return message.Record;
});
```

But `async/await` makes continuation execute on the same thread context, not the same thread. While the code itself seems convenient and like something everybody could write to achieve documented behavior (and actually this way is already used in one of our tests), this looks like inaccurate translation from scala. 

Other option I see here is something like this:
```c#
return CommittableSource(settings, subscription).SelectAsync(1, message =>
{
   return message.CommitableOffset.Commit().ContinueWith(_ => message.Record, TaskContinuationOptions.ExecuteSynchronously);
});
```

This looks much more similar to what is written in scala, but I have never used `TaskContinuationOptions.ExecuteSynchronously` option so far and not sure this is something we need to use. Here is a [docs](https://docs.microsoft.com/en-us/dotnet/api/system.threading.tasks.taskcontinuationoptions?view=netframework-4.8) for it - should I use this way instead? @Aaronontheweb what do you think?

I have found some [akka.net issue](https://github.com/akkadotnet/akka.net/issues/147) that was also related to `ExecutionContexts.sameThreadExecutionContext` - but looks like guys decided to not implement this in akka.net packages. 

PR is still in progress, because I need to add tests for this. But I suspect that tests will pass with both implementations - so just need to make a decision about how to implement that.
