### PR TITLE
SourceWithOffsetContext

### DIFF
--- a/src/Akka.Streams.Kafka.Tests/Integration/AtMostOnceSourceIntegrationTests.cs
+++ b/src/Akka.Streams.Kafka.Tests/Integration/AtMostOnceSourceIntegrationTests.cs
@@ -60,7 +60,7 @@ namespace Akka.Streams.Kafka.Tests.Integration
 
             probe.Request(10);
             
-            AwaitCondition(() => lastMessage.Task.IsCompletedSuccessfully, TimeSpan.FromSeconds(15));
+            AwaitCondition(() => lastMessage.Task.IsCompletedSuccessfully, TimeSpan.FromSeconds(20));
            
             probe.Cancel();
             

--- a/src/Akka.Streams.Kafka.Tests/Integration/AtMostOnceSourceIntegrationTests.cs
+++ b/src/Akka.Streams.Kafka.Tests/Integration/AtMostOnceSourceIntegrationTests.cs
@@ -60,7 +60,7 @@ namespace Akka.Streams.Kafka.Tests.Integration
 
             probe.Request(10);
             
-            AwaitCondition(() => lastMessage.Task.IsCompletedSuccessfully, TimeSpan.FromSeconds(20));
+            AwaitCondition(() => lastMessage.Task.IsCompletedSuccessfully, TimeSpan.FromSeconds(30));
            
             probe.Cancel();
             

--- a/src/Akka.Streams.Kafka.Tests/Integration/SourceWithOffsetContextIntegrationTests.cs
+++ b/src/Akka.Streams.Kafka.Tests/Integration/SourceWithOffsetContextIntegrationTests.cs
@@ -1,7 +1,13 @@
+using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Akka.Streams.Dsl;
 using Akka.Streams.Kafka.Dsl;
+using Akka.Streams.Kafka.Helpers;
+using Akka.Streams.Kafka.Messages;
 using Akka.Streams.Kafka.Settings;
+using Akka.Streams.TestKit;
+using FluentAssertions;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -15,14 +21,29 @@ namespace Akka.Streams.Kafka.Tests.Integration
         }
 
         [Fact]
-        public async Task SourceWithOffsetContext_should_work()
+        public async Task SourceWithOffsetContext_at_least_once_consuming_should_work()
         {
             var topic = CreateTopic(1);
             var settings = CreateConsumerSettings<string>(CreateGroup(1));
+            var messages = Enumerable.Range(1, 10).ToList();
+
+            await ProduceStrings(topic, messages, ProducerSettings);
             
-            var task = KafkaConsumer.SourceWithOffsetContext(settings, Subscriptions.Topics(topic))
+            var (task, probe) = KafkaConsumer.SourceWithOffsetContext(settings, Subscriptions.Topics(topic))
                 .SelectAsync(10, message => Task.FromResult(Done.Instance))
-                .Via()
+                .Via(Committer.FlowWithOffsetContext<Done>(CommitterSettings))
+                .AsSource()
+                .ToMaterialized(this.SinkProbe<Tuple<NotUsed, ICommittableOffsetBatch>>(), Keep.Both)
+                .Run(Materializer);
+
+            probe.Request(10);
+            var committedBatches = probe.Within(TimeSpan.FromSeconds(10), () => probe.ExpectNextN(10));
+
+            probe.Cancel();
+            
+            AwaitCondition(() => task.IsCompletedSuccessfully, TimeSpan.FromSeconds(10));
+
+            committedBatches.Select(r => r.Item2).Sum(batch => batch.BatchSize).Should().Be(10);
         }
     }
 }

--- a/src/Akka.Streams.Kafka.Tests/Integration/SourceWithOffsetContextIntegrationTests.cs
+++ b/src/Akka.Streams.Kafka.Tests/Integration/SourceWithOffsetContextIntegrationTests.cs
@@ -1,0 +1,28 @@
+using System.Threading.Tasks;
+using Akka.Streams.Dsl;
+using Akka.Streams.Kafka.Dsl;
+using Akka.Streams.Kafka.Settings;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Akka.Streams.Kafka.Tests.Integration
+{
+    public class SourceWithOffsetContextIntegrationTests : KafkaIntegrationTests
+    {
+        public SourceWithOffsetContextIntegrationTests(ITestOutputHelper output, KafkaFixture fixture) 
+            : base(nameof(SourceWithOffsetContextIntegrationTests), output, fixture)
+        {
+        }
+
+        [Fact]
+        public async Task SourceWithOffsetContext_should_work()
+        {
+            var topic = CreateTopic(1);
+            var settings = CreateConsumerSettings<string>(CreateGroup(1));
+            
+            var task = KafkaConsumer.SourceWithOffsetContext(settings, Subscriptions.Topics(topic))
+                .SelectAsync(10, message => Task.FromResult(Done.Instance))
+                .Via()
+        }
+    }
+}

--- a/src/Akka.Streams.Kafka.Tests/KafkaIntegrationTests.cs
+++ b/src/Akka.Streams.Kafka.Tests/KafkaIntegrationTests.cs
@@ -44,7 +44,7 @@ namespace Akka.Streams.Kafka.Tests
 
         protected CommitterSettings CommitterSettings
         {
-            get => CommitterSettings.Create(Sys).WithMaxBatch(1).WithMaxInterval(TimeSpan.FromSeconds(1)).WithParallelism(1);
+            get => CommitterSettings.Create(Sys);
         }
 
         protected ConsumerSettings<Null, TValue> CreateConsumerSettings<TValue>(string group)

--- a/src/Akka.Streams.Kafka.Tests/KafkaIntegrationTests.cs
+++ b/src/Akka.Streams.Kafka.Tests/KafkaIntegrationTests.cs
@@ -42,6 +42,11 @@ namespace Akka.Streams.Kafka.Tests
             get => ProducerSettings<Null, string>.Create(Sys, null, null).WithBootstrapServers(_fixture.KafkaServer);
         }
 
+        protected CommitterSettings CommitterSettings
+        {
+            get => CommitterSettings.Create(Sys).WithMaxBatch(1).WithMaxInterval(TimeSpan.FromSeconds(1)).WithParallelism(1);
+        }
+
         protected ConsumerSettings<Null, TValue> CreateConsumerSettings<TValue>(string group)
         {
             return ConsumerSettings<Null, TValue>.Create(Sys, null, null)

--- a/src/Akka.Streams.Kafka/Dsl/KafkaConsumer.cs
+++ b/src/Akka.Streams.Kafka/Dsl/KafkaConsumer.cs
@@ -68,7 +68,7 @@ namespace Akka.Streams.Kafka.Dsl
         // TODO: Add 'see' tags to this method documentation
         [ApiMayChange]
         public static SourceWithContext<ICommittableOffset, ConsumeResult<K, V>, Task> SourceWithOffsetContext<K, V>(
-            ConsumerSettings<K, V> settings, ISubscription subscription, Func<ConsumeResult<K, V>, string> metadataFromRecord)
+            ConsumerSettings<K, V> settings, ISubscription subscription, Func<ConsumeResult<K, V>, string> metadataFromRecord = null)
         {
             return Source.FromGraph(new SourceWithOffsetContextStage<K, V>(settings, subscription, metadataFromRecord))
                 .AsSourceWithContext(m => m.Item2)

--- a/src/Akka.Streams.Kafka/Dsl/KafkaConsumer.cs
+++ b/src/Akka.Streams.Kafka/Dsl/KafkaConsumer.cs
@@ -66,7 +66,6 @@ namespace Akka.Streams.Kafka.Dsl
         /// It is intended to be used with Akka's [flow with context](https://doc.akka.io/docs/akka/current/stream/operators/Flow/asFlowWithContext.html),
         /// <see cref="KafkaProducer.FlowWithContext{K,V,C}"/> and/or <see cref="Committer.SinkWithOffsetContext{E}"/>
         /// </summary>
-        // TODO: Add 'see' tags to this method documentation
         [ApiMayChange]
         public static SourceWithContext<ICommittableOffset, ConsumeResult<K, V>, Task> SourceWithOffsetContext<K, V>(
             ConsumerSettings<K, V> settings, ISubscription subscription, Func<ConsumeResult<K, V>, string> metadataFromRecord = null)

--- a/src/Akka.Streams.Kafka/Dsl/KafkaConsumer.cs
+++ b/src/Akka.Streams.Kafka/Dsl/KafkaConsumer.cs
@@ -1,5 +1,7 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using Akka.Actor;
+using Akka.Annotations;
 using Akka.Streams.Dsl;
 using Akka.Streams.Kafka.Settings;
 using Akka.Streams.Kafka.Stages;
@@ -50,6 +52,27 @@ namespace Akka.Streams.Kafka.Dsl
         public static Source<CommittableMessage<K, V>, Task> CommittableSource<K, V>(ConsumerSettings<K, V> settings, ISubscription subscription)
         {
             return Source.FromGraph(new CommittableSourceStage<K, V>(settings, subscription));
+        }
+
+        /// <summary>
+        /// API MAY CHANGE
+        ///
+        /// This source emits <see cref="ConsumeResult{TKey,TValue}"/> together with the offset position as flow context, thus makes it possible
+        /// to commit offset positions to Kafka.
+        /// This is useful when "at-least once delivery" is desired, as each message will likely be
+        /// delivered one time but in failure cases could be duplicated.
+        ///
+        /// It is intended to be used with Akka's [flow with context](https://doc.akka.io/docs/akka/current/stream/operators/Flow/asFlowWithContext.html),
+        /// 'Producer.FlowWithContext' and/or 'Committer.SinkWithOffsetContext'
+        /// </summary>
+        // TODO: Add 'see' tags to this method documentation
+        [ApiMayChange]
+        public static SourceWithContext<ICommittableOffset, ConsumeResult<K, V>, Task> SourceWithOffsetContext<K, V>(
+            ConsumerSettings<K, V> settings, ISubscription subscription, Func<ConsumeResult<K, V>, string> metadataFromRecord)
+        {
+            return Source.FromGraph(new SourceWithOffsetContextStage<K, V>(settings, subscription, metadataFromRecord))
+                .AsSourceWithContext(m => m.Item2)
+                .Select(m => m.Item1);
         }
     }
 }

--- a/src/Akka.Streams.Kafka/Dsl/KafkaConsumer.cs
+++ b/src/Akka.Streams.Kafka/Dsl/KafkaConsumer.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Annotations;
 using Akka.Streams.Dsl;
+using Akka.Streams.Kafka.Helpers;
 using Akka.Streams.Kafka.Settings;
 using Akka.Streams.Kafka.Stages;
 using Confluent.Kafka;
@@ -63,7 +64,7 @@ namespace Akka.Streams.Kafka.Dsl
         /// delivered one time but in failure cases could be duplicated.
         ///
         /// It is intended to be used with Akka's [flow with context](https://doc.akka.io/docs/akka/current/stream/operators/Flow/asFlowWithContext.html),
-        /// 'Producer.FlowWithContext' and/or 'Committer.SinkWithOffsetContext'
+        /// <see cref="KafkaProducer.FlowWithContext{K,V,C}"/> and/or <see cref="Committer.SinkWithOffsetContext{E}"/>
         /// </summary>
         // TODO: Add 'see' tags to this method documentation
         [ApiMayChange]

--- a/src/Akka.Streams.Kafka/Dsl/KafkaProducer.cs
+++ b/src/Akka.Streams.Kafka/Dsl/KafkaProducer.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using Akka.Streams.Dsl;
 using Akka.Streams.Kafka.Messages;
 using Akka.Streams.Kafka.Settings;
@@ -65,6 +66,12 @@ namespace Akka.Streams.Kafka.Dsl
             return string.IsNullOrEmpty(settings.DispatcherId)
                 ? flow
                 : flow.WithAttributes(ActorAttributes.CreateDispatcher(settings.DispatcherId));
+        }
+
+        // TODO
+        public static FlowWithContext<IEnvelope<K, V, NotUsed>, C, DeliveryReport<K, V>, C, NotUsed> FlowWithContext<K, V, C>(ProducerSettings<K, V> settings)
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/src/Akka.Streams.Kafka/Helpers/Committer.cs
+++ b/src/Akka.Streams.Kafka/Helpers/Committer.cs
@@ -1,0 +1,26 @@
+using Akka.Streams.Dsl;
+using Akka.Streams.Kafka.Messages;
+using Akka.Streams.Kafka.Settings;
+
+namespace Akka.Streams.Kafka.Helpers
+{
+    /// <summary>
+    /// Implements committing flows
+    /// </summary>
+    public static class Committer
+    {
+        /// <summary>
+        /// Batches offsets and commits them to Kafka, emits <see cref="CommittableOffsetBatch"/> for every committed batch.
+        /// </summary>
+        public static Flow<ICommittable, ICommittableOffsetBatch, NotUsed> BatchFlow(CommitterSettings settings)
+        {
+            return Flow.Create<ICommittable>().GroupedWithin(settings.MaxBatch, settings.MaxInterval)
+                .Select(CommittableOffsetBatch.Create)
+                .SelectAsync(settings.Parallelism, async batch =>
+                {
+                   await batch.Commit();
+                   return batch;
+                });
+        }
+    }
+}

--- a/src/Akka.Streams.Kafka/Helpers/Committer.cs
+++ b/src/Akka.Streams.Kafka/Helpers/Committer.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Threading.Tasks;
+using Akka.Annotations;
 using Akka.Streams.Dsl;
 using Akka.Streams.Kafka.Messages;
 using Akka.Streams.Kafka.Settings;
@@ -14,13 +17,59 @@ namespace Akka.Streams.Kafka.Helpers
         /// </summary>
         public static Flow<ICommittable, ICommittableOffsetBatch, NotUsed> BatchFlow(CommitterSettings settings)
         {
-            return Flow.Create<ICommittable>().GroupedWithin(settings.MaxBatch, settings.MaxInterval)
+            return Akka.Streams.Dsl.Flow.Create<ICommittable>().GroupedWithin(settings.MaxBatch, settings.MaxInterval)
                 .Select(CommittableOffsetBatch.Create)
                 .SelectAsync(settings.Parallelism, async batch =>
                 {
                    await batch.Commit();
                    return batch;
                 });
+        }
+
+        /// <summary>
+        /// Batches offsets and commits them to Kafka, emits <see cref="Done.Instance"/> for every committed batch.
+        /// </summary>
+        public static Flow<ICommittable, Done, NotUsed> Flow(CommitterSettings settings)
+        {
+            return BatchFlow(settings).Select(_ => Done.Instance);
+        }
+
+        /// <summary>
+        /// API MAY CHANGE
+        /// 
+        /// Batches offsets from context and commits them to Kafka, emits no useful value,
+        /// but keeps the committed <see cref="ICommittableOffsetBatch"/> as context
+        /// </summary>
+        [ApiMayChange]
+        public static FlowWithContext<ICommittableOffset, E, ICommittableOffsetBatch, NotUsed, NotUsed> FlowWithOffsetContext<E>(CommitterSettings settings)
+        {
+            var value = Akka.Streams.Dsl.Flow.Create<Tuple<E, ICommittableOffset>>()
+                .Select(m => m.Item2 as ICommittable)
+                .Via(BatchFlow(settings))
+                .Select(b => Tuple.Create(NotUsed.Instance, b));
+
+            return FlowWithContext.From(value);
+        }
+
+        /// <summary>
+        /// Batches offsets and commits them to Kafka.
+        /// </summary>
+        public static Sink<ICommittable, Task> Sink(CommitterSettings settings)
+        {
+            return Flow(settings).ToMaterialized(Streams.Dsl.Sink.Ignore<Done>(), Keep.Right);
+        }
+
+        /// <summary>
+        /// API MAY CHANGE
+        /// 
+        /// Batches offsets from context and commits them to Kafka.
+        /// </summary>
+        [ApiMayChange]
+        public static Sink<Tuple<E, ICommittableOffset>, Task> SinkWithOffsetContext<E>(CommitterSettings settings)
+        {
+            return Akka.Streams.Dsl.Flow.Create<Tuple<E, ICommittableOffset>>()
+                .Via(FlowWithOffsetContext<E>(settings))
+                .ToMaterialized(Streams.Dsl.Sink.Ignore<Tuple<NotUsed, ICommittableOffsetBatch>>(), Keep.Right);
         }
     }
 }

--- a/src/Akka.Streams.Kafka/Messages/Committable.cs
+++ b/src/Akka.Streams.Kafka/Messages/Committable.cs
@@ -1,0 +1,66 @@
+using System.Collections.Immutable;
+using System.Threading.Tasks;
+
+namespace Akka.Streams.Kafka.Messages
+{
+   /// <summary>
+    /// Commit an offset that is included in a <see cref="CommittableMessage{K,V}"/>
+    /// If you need to store offsets in anything other than Kafka, this API
+    /// should not be used.
+    /// </summary>
+    public interface ICommittable
+    {
+        /// <summary>
+        /// Commits an offset that is included in a <see cref="CommittableMessage{K,V}"/> 
+        /// </summary>
+        Task Commit();
+        /// <summary>
+        /// Get a number of processed messages this committable contains
+        /// </summary>
+        long BatchSize { get; }
+    }
+
+    /// <summary>
+    /// For improved efficiency it is good to aggregate several <see cref="ICommittableOffset"/>,
+    /// using this class, befoe <see cref="ICommittable.Commit"/> them.
+    /// Start with 
+    /// </summary>
+    public interface ICommittableOffsetBatch : ICommittable
+    {
+        /// <summary>
+        /// Add/overwrite an offset position from another committable.
+        /// </summary>
+        ICommittableOffsetBatch Updated(ICommittable offset);
+        /// <summary>
+        /// Get current offset positions
+        /// </summary>
+        IImmutableSet<GroupTopicPartitionOffset> Offsets { get; }
+    }
+
+    /// <summary>
+    /// Included in <see cref="CommittableMessage{K,V}"/>. Makes it possible to
+    /// commit an offset or aggregate several offsets before committing.
+    /// Note that the offset position that is committed to Kafka will automatically
+    /// be one more than the `offset` of the message, because the committed offset
+    /// should be the next message your application will consume,
+    /// i.e. lastProcessedMessageOffset + 1.
+    /// </summary>
+    public interface ICommittableOffset : ICommittable
+    {
+        /// <summary>
+        /// Offset value
+        /// </summary>
+        GroupTopicPartitionOffset Offset { get; }
+    }
+
+    /// <summary>
+    /// Extends <see cref="ICommittableOffset"/> with some metadata
+    /// </summary>
+    public interface ICommittableOffsetMetadata : ICommittableOffset
+    {
+        /// <summary>
+        /// Cosumed record metadata
+        /// </summary>
+        string Metadata { get; }
+    }
+}

--- a/src/Akka.Streams.Kafka/Messages/CommittableMessage.cs
+++ b/src/Akka.Streams.Kafka/Messages/CommittableMessage.cs
@@ -1,9 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 using System.Threading.Tasks;
 using Akka.Streams.Kafka.Dsl;
-using Akka.Streams.Kafka.Stages.Consumers;
 using Confluent.Kafka;
 
 namespace Akka.Streams.Kafka.Messages
@@ -28,109 +25,5 @@ namespace Akka.Streams.Kafka.Messages
         /// Consumer offset that can be commited
         /// </summary>
         public ICommittableOffset CommitableOffset { get; }
-    }
-
-    /// <summary>
-    /// Commit an offset that is included in a <see cref="CommittableMessage{K,V}"/>
-    /// If you need to store offsets in anything other than Kafka, this API
-    /// should not be used.
-    /// </summary>
-    public interface ICommittable
-    {
-        /// <summary>
-        /// Commits an offset that is included in a <see cref="CommittableMessage{K,V}"/> 
-        /// </summary>
-        Task Commit();
-    }
-
-    /// <summary>
-    /// Included in <see cref="CommittableMessage{K,V}"/>. Makes it possible to
-    /// commit an offset or aggregate several offsets before committing.
-    /// Note that the offset position that is committed to Kafka will automatically
-    /// be one more than the `offset` of the message, because the committed offset
-    /// should be the next message your application will consume,
-    /// i.e. lastProcessedMessageOffset + 1.
-    /// </summary>
-    public interface ICommittableOffset : ICommittable
-    {
-        /// <summary>
-        /// Offset value
-        /// </summary>
-        PartitionOffset Offset { get; }
-    }
-
-    /// <summary>
-    /// Extends <see cref="ICommittableOffset"/> with some metadata
-    /// </summary>
-    public interface ICommittableOffsetMetadata : ICommittableOffset
-    {
-        /// <summary>
-        /// Cosumed record metadata
-        /// </summary>
-        string Metadata { get; }
-    }
-
-    /// <summary>
-    /// Implementation of the offset, contained in <see cref="CommittableMessage{K,V}"/>.
-    /// Can be commited via <see cref="Commit"/> method.
-    /// </summary>
-    internal class CommittableOffset : ICommittableOffsetMetadata
-    {
-        private readonly IInternalCommitter _committer;
-        
-        /// <summary>
-        /// Offset value
-        /// </summary>
-        public PartitionOffset Offset { get; }
-        /// <summary>
-        /// Cosumed record metadata
-        /// </summary>
-        public string Metadata { get; }
-
-        public CommittableOffset(IInternalCommitter committer, PartitionOffset offset, string metadata)
-        {
-            _committer = committer;
-            Offset = offset;
-            Metadata = metadata;
-        }
-
-        /// <summary>
-        /// Commits offset to Kafka
-        /// </summary>
-        public Task Commit()
-        {
-            return _committer.Commit(ImmutableList.Create(Offset));
-        }
-    }
-
-    /// <summary>
-    /// Offset position for a groupId, topic, partition.
-    /// </summary>
-    public class PartitionOffset
-    {
-        public PartitionOffset(string groupId, string topic, int partition, Offset offset)
-        {
-            GroupId = groupId;
-            Topic = topic;
-            Partition = partition;
-            Offset = offset;
-        }
-
-        /// <summary>
-        /// Consumer's group Id
-        /// </summary>
-        public string GroupId { get; }
-        /// <summary>
-        /// Topic
-        /// </summary>
-        public string Topic { get; }
-        /// <summary>
-        /// Partition
-        /// </summary>
-        public int Partition { get; }
-        /// <summary>
-        /// Kafka partition offset value
-        /// </summary>
-        public Offset Offset { get; }
     }
 }

--- a/src/Akka.Streams.Kafka/Messages/CommittableOffset.cs
+++ b/src/Akka.Streams.Kafka/Messages/CommittableOffset.cs
@@ -1,0 +1,43 @@
+using System.Collections.Immutable;
+using System.Threading.Tasks;
+using Akka.Streams.Kafka.Stages.Consumers;
+
+namespace Akka.Streams.Kafka.Messages
+{
+    /// <summary>
+    /// Implementation of the offset, contained in <see cref="CommittableMessage{K,V}"/>.
+    /// Can be commited via <see cref="Commit"/> method.
+    /// </summary>
+    internal sealed class CommittableOffset : ICommittableOffsetMetadata
+    {
+        /// <inheritdoc />
+        public long BatchSize => 1;
+        /// <summary>
+        /// Offset value
+        /// </summary>
+        public GroupTopicPartitionOffset Offset { get; }
+        /// <summary>
+        /// Cosumed record metadata
+        /// </summary>
+        public string Metadata { get; }
+        /// <summary>
+        /// Committer
+        /// </summary>
+        public IInternalCommitter Committer { get; }
+
+        public CommittableOffset(IInternalCommitter committer, GroupTopicPartitionOffset offset, string metadata)
+        {
+            Committer = committer;
+            Offset = offset;
+            Metadata = metadata;
+        }
+
+        /// <summary>
+        /// Commits offset to Kafka
+        /// </summary>
+        public Task Commit()
+        {
+            return Committer.Commit(ImmutableList.Create(Offset));
+        }
+    }
+}

--- a/src/Akka.Streams.Kafka/Messages/CommittableOffsetBatch.cs
+++ b/src/Akka.Streams.Kafka/Messages/CommittableOffsetBatch.cs
@@ -8,11 +8,17 @@ using Akka.Streams.Kafka.Stages.Consumers;
 
 namespace Akka.Streams.Kafka.Messages
 {
+    /// <summary>
+    /// Stores committable offsets batch and allows to commit them with <see cref="Commit"/> method
+    /// </summary>
     internal sealed class CommittableOffsetBatch : ICommittableOffsetBatch
     {
+        /// <summary>
+        /// CommittableOffsetBatch
+        /// </summary>
         public CommittableOffsetBatch(IImmutableDictionary<GroupTopicPartition, OffsetAndMetadata> offsetsAndMetadata, 
-            IImmutableDictionary<string, IInternalCommitter> committers, 
-            long batchSize)
+                                      IImmutableDictionary<string, IInternalCommitter> committers, 
+                                      long batchSize)
         {
             OffsetsAndMetadata = offsetsAndMetadata;
             Committers = committers;
@@ -78,6 +84,9 @@ namespace Akka.Streams.Kafka.Messages
             }
         }
 
+        /// <summary>
+        /// Adds offsets from given committable batch to existing ones
+        /// </summary>
         private ICommittableOffsetBatch UpdateWithBatch(ICommittableOffsetBatch committableOffsetBatch)
         {
             if (!(committableOffsetBatch is CommittableOffsetBatch committableOffsetBatchImpl))
@@ -107,6 +116,9 @@ namespace Akka.Streams.Kafka.Messages
             return new CommittableOffsetBatch(newOffsetsAndMetdata, newCommitters, BatchSize + committableOffsetBatchImpl.BatchSize);
         }
 
+        /// <summary>
+        /// Adds committable offset to existing ones
+        /// </summary>
         private ICommittableOffsetBatch UpdateWithOffset(ICommittableOffset committableOffset)
         {
             var partitionOffset = committableOffset.Offset;

--- a/src/Akka.Streams.Kafka/Messages/CommittableOffsetBatch.cs
+++ b/src/Akka.Streams.Kafka/Messages/CommittableOffsetBatch.cs
@@ -1,0 +1,140 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading.Tasks;
+using Akka.Streams.Kafka.Extensions;
+using Akka.Streams.Kafka.Stages.Consumers;
+
+namespace Akka.Streams.Kafka.Messages
+{
+    internal sealed class CommittableOffsetBatch : ICommittableOffsetBatch
+    {
+        public CommittableOffsetBatch(IImmutableDictionary<GroupTopicPartition, OffsetAndMetadata> offsetsAndMetadata, 
+            IImmutableDictionary<string, IInternalCommitter> committers, 
+            long batchSize)
+        {
+            OffsetsAndMetadata = offsetsAndMetadata;
+            Committers = committers;
+            BatchSize = batchSize;
+        }
+
+        /// <inheritdoc />
+        public long BatchSize { get; }
+        
+        /// <inheritdoc />
+        public IImmutableSet<GroupTopicPartitionOffset> Offsets => OffsetsAndMetadata.Select(o => new GroupTopicPartitionOffset(o.Key, o.Value.Offset)).ToImmutableHashSet();
+        
+        /// <summary>
+        /// Committers
+        /// </summary>
+        public IImmutableDictionary<string, IInternalCommitter> Committers { get; }
+        
+        /// <summary>
+        /// Offsets and metadata
+        /// </summary>
+        public IImmutableDictionary<GroupTopicPartition, OffsetAndMetadata> OffsetsAndMetadata { get; }
+        
+        /// <summary>
+        /// Create empty offset batch
+        /// </summary>
+        public static ICommittableOffsetBatch Empty => new CommittableOffsetBatch(ImmutableDictionary<GroupTopicPartition, OffsetAndMetadata>.Empty, 
+                                                                                  ImmutableDictionary<string, IInternalCommitter>.Empty, 
+                                                                                  0);
+        
+        /// <summary>
+        /// Create an offset batch out of a first offsets.
+        /// </summary>
+        public static ICommittableOffsetBatch Create(ICommittableOffset offset) => Empty.Updated(offset);
+        /// <summary>
+        /// Create an offset batch out of a list of offsets.
+        /// </summary>
+        public static ICommittableOffsetBatch Create(IEnumerable<ICommittable> offsets)
+        {
+            return offsets.Aggregate(Empty, (batch, offset) => batch.Updated(offset));
+        }
+
+        /// <inheritdoc />
+        public async Task Commit()
+        {
+            if (Offsets.IsEmpty() || Committers.IsEmpty())
+                return;
+
+            await Committers.First().Value.Commit(this);
+        }
+
+        /// <inheritdoc />
+        public ICommittableOffsetBatch Updated(ICommittable offset)
+        {
+            switch (offset)
+            {
+                case ICommittableOffset committableOffset:
+                    return UpdateWithOffset(committableOffset);
+                    break;
+                case ICommittableOffsetBatch committableOffsetBatch:
+                    return UpdateWithBatch(committableOffsetBatch);
+                default:
+                    throw new AggregateException($"Unexpected offset to update committable batch offsets from: {offset.GetType().Name}");
+            }
+        }
+
+        private ICommittableOffsetBatch UpdateWithBatch(ICommittableOffsetBatch committableOffsetBatch)
+        {
+            if (!(committableOffsetBatch is CommittableOffsetBatch committableOffsetBatchImpl))
+                throw new ArgumentException($"Unexpected CommittableOffsetBatch, got {committableOffsetBatch.GetType().Name}, expected {nameof(CommittableOffsetBatch)}");
+
+            var newOffsetsAndMetdata = OffsetsAndMetadata.SetItems(committableOffsetBatchImpl.OffsetsAndMetadata);
+            var newCommitters = committableOffsetBatchImpl.Committers.Aggregate(Committers, (committers, pair) =>
+            {
+                var groupId = pair.Key;
+                var committer = pair.Value;
+                if (committers.TryGetValue(groupId, out var groupCommitter))
+                {
+                    if (!groupCommitter.Equals(committer))
+                    {
+                        throw new ArgumentException($"CommittableOffsetBatch {committableOffsetBatch} committer for groupId {groupId} " +
+                                                    $"must be same as the other with this groupId.");
+                    }
+
+                    return committers;
+                }
+                else
+                {
+                    return committers.Add(groupId, committer);
+                }
+            }).ToImmutableDictionary(pair => pair.Key, pair => pair.Value);
+            
+            return new CommittableOffsetBatch(newOffsetsAndMetdata, newCommitters, BatchSize + committableOffsetBatchImpl.BatchSize);
+        }
+
+        private ICommittableOffsetBatch UpdateWithOffset(ICommittableOffset committableOffset)
+        {
+            var partitionOffset = committableOffset.Offset;
+            var metadata = (committableOffset is ICommittableOffsetMetadata withMetadata) ? withMetadata.Metadata : string.Empty;
+
+            var newOffsets = OffsetsAndMetadata.SetItem(partitionOffset.GroupTopicPartition, new OffsetAndMetadata(partitionOffset.Offset, metadata));
+            var committer = committableOffset is CommittableOffset c 
+                ? c.Committer 
+                : throw new ArgumentException($"Unknown committable offset, got {committableOffset.GetType().Name}, expected {nameof(committableOffset)}");
+            
+            
+            IImmutableDictionary<string, IInternalCommitter> newCommitters = ImmutableDictionary<string, IInternalCommitter>.Empty;
+            if (Committers.TryGetValue(partitionOffset.GroupId, out var groupCommitter))
+            {
+                if (!groupCommitter.Equals(committer))
+                {
+                    throw new ArgumentException($"CommittableOffset {committableOffset} committer for groupId {partitionOffset.GroupId} " +
+                                                $"must be same as the other with this groupId.");
+                }
+
+                newCommitters = Committers;
+            }
+            else
+            {
+                Committers.SetItem(partitionOffset.GroupId, committer);
+            }
+            
+            return new CommittableOffsetBatch(newOffsets, newCommitters, BatchSize + 1);
+        }
+    }
+}

--- a/src/Akka.Streams.Kafka/Messages/Envelope.cs
+++ b/src/Akka.Streams.Kafka/Messages/Envelope.cs
@@ -1,0 +1,7 @@
+namespace Akka.Streams.Kafka.Messages
+{
+    public interface IEnvelope<K, V, TPassThrough>
+    {
+        // TODO
+    }
+}

--- a/src/Akka.Streams.Kafka/Messages/GroupTopicPartitionOffset.cs
+++ b/src/Akka.Streams.Kafka/Messages/GroupTopicPartitionOffset.cs
@@ -1,0 +1,153 @@
+using System;
+using Confluent.Kafka;
+
+namespace Akka.Streams.Kafka.Messages
+{
+    /// <summary>
+    /// Offset position for a groupId, topic, partition.
+    /// </summary>
+    public sealed class GroupTopicPartitionOffset : IEquatable<GroupTopicPartitionOffset>
+    {
+        /// <summary>
+        /// GroupTopicPartitionOffset
+        /// </summary>
+        public GroupTopicPartitionOffset(string groupId, string topic, int partition, Offset offset)
+        {
+            GroupId = groupId;
+            Topic = topic;
+            Partition = partition;
+            Offset = offset;
+        }
+
+        /// <summary>
+        /// GroupTopicPartitionOffset
+        /// </summary>
+        public GroupTopicPartitionOffset(GroupTopicPartition groupTopicPartition, Offset offset)
+            : this(groupTopicPartition.GroupId, groupTopicPartition.Topic, groupTopicPartition.Partition, offset)
+        {
+        }
+
+        /// <summary>
+        /// Consumer's group Id
+        /// </summary>
+        public string GroupId { get; }
+        /// <summary>
+        /// Topic
+        /// </summary>
+        public string Topic { get; }
+        /// <summary>
+        /// Partition
+        /// </summary>
+        public int Partition { get; }
+        /// <summary>
+        /// Kafka partition offset value
+        /// </summary>
+        public Offset Offset { get; }
+        /// <summary>
+        /// Group topic partition info
+        /// </summary>
+        public GroupTopicPartition GroupTopicPartition => new GroupTopicPartition(GroupId, Topic, Partition);
+
+        public bool Equals(GroupTopicPartitionOffset other)
+        {
+            if (ReferenceEquals(null, other)) return false;
+            if (ReferenceEquals(this, other)) return true;
+            return GroupId == other.GroupId && Topic == other.Topic && Partition == other.Partition && Offset.Equals(other.Offset);
+        }
+
+        public override bool Equals(object obj) => ReferenceEquals(this, obj) || obj is GroupTopicPartitionOffset other && Equals(other);
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = (GroupId != null ? GroupId.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ (Topic != null ? Topic.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ Partition;
+                hashCode = (hashCode * 397) ^ Offset.GetHashCode();
+                return hashCode;
+            }
+        }
+    }
+    
+    /// <summary>
+    /// Group, topic and partition info
+    /// </summary>
+    public sealed class GroupTopicPartition : IEquatable<GroupTopicPartition>
+    {
+        public GroupTopicPartition(string groupId, string topic, int partition)
+        {
+            GroupId = groupId;
+            Topic = topic;
+            Partition = partition;
+        }
+        
+        /// <summary>
+        /// Consumer's group Id
+        /// </summary>
+        public string GroupId { get; }
+        /// <summary>
+        /// Topic
+        /// </summary>
+        public string Topic { get; }
+        /// <summary>
+        /// Partition
+        /// </summary>
+        public int Partition { get; }
+
+        public bool Equals(GroupTopicPartition other)
+        {
+            if (ReferenceEquals(null, other)) return false;
+            if (ReferenceEquals(this, other)) return true;
+            return GroupId == other.GroupId && Topic == other.Topic && Partition == other.Partition;
+        }
+
+        public override bool Equals(object obj) => ReferenceEquals(this, obj) || obj is GroupTopicPartition other && Equals(other);
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = (GroupId != null ? GroupId.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ (Topic != null ? Topic.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ Partition;
+                return hashCode;
+            }
+        }
+    }
+
+    public sealed class OffsetAndMetadata : IEquatable<OffsetAndMetadata>
+    {
+        public OffsetAndMetadata(Offset offset, string metadata)
+        {
+            Offset = offset;
+            Metadata = metadata;
+        }
+
+        /// <summary>
+        /// Kafka partition offset value
+        /// </summary>
+        public Offset Offset { get; }
+        /// <summary>
+        /// Metadata
+        /// </summary>
+        public string Metadata { get; }
+
+        public bool Equals(OffsetAndMetadata other)
+        {
+            if (ReferenceEquals(null, other)) return false;
+            if (ReferenceEquals(this, other)) return true;
+            return Offset.Equals(other.Offset) && Metadata == other.Metadata;
+        }
+
+        public override bool Equals(object obj) => ReferenceEquals(this, obj) || obj is OffsetAndMetadata other && Equals(other);
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return (Offset.GetHashCode() * 397) ^ (Metadata != null ? Metadata.GetHashCode() : 0);
+            }
+        }
+    }
+}

--- a/src/Akka.Streams.Kafka/Settings/CommitterSettings.cs
+++ b/src/Akka.Streams.Kafka/Settings/CommitterSettings.cs
@@ -1,0 +1,83 @@
+using System;
+using Akka.Actor;
+using Akka.Configuration;
+
+namespace Akka.Streams.Kafka.Settings
+{
+    /// <summary>
+    /// Settings for committer. See 'akka.kafka.committer' section in reference.conf.
+    /// </summary>
+    public sealed class CommitterSettings
+    {
+        /// <summary>
+        /// CommitterSettings
+        /// </summary>
+        /// <param name="maxBatch">Max commit batch size</param>
+        /// <param name="maxInterval">Max commit interval</param>
+        /// <param name="parallelism">Level of parallelism</param>
+        public CommitterSettings(int maxBatch, TimeSpan maxInterval, int parallelism)
+        {
+            MaxBatch = maxBatch;
+            MaxInterval = maxInterval;
+            Parallelism = parallelism;
+        }
+
+        /// <summary>
+        /// Creates committer settings
+        /// </summary>
+        /// <param name="system">Actor system for stage materialization</param>
+        /// <returns>Committer settings</returns>
+        public static CommitterSettings Create(ActorSystem system)
+        {
+            var config = system.Settings.Config.GetConfig("akka.kafka.committer");
+            return Create(config);
+        }
+
+        /// <summary>
+        /// Creates committer settings
+        /// </summary>
+        /// <param name="config">Config to load properties from</param>
+        /// <returns>Committer settings</returns>
+        public static CommitterSettings Create(Config config)
+        {
+            var maxBatch = config.GetInt("max-batch");
+            var maxInterval = config.GetTimeSpan("max-interval");
+            var parallelism = config.GetInt("parallelism");
+            return new CommitterSettings(maxBatch, maxInterval, parallelism);
+        }
+        
+        /// <summary>
+        /// Max commit batch size
+        /// </summary>
+        public int MaxBatch { get; }
+        /// <summary>
+        /// Max commit interval
+        /// </summary>
+        public TimeSpan MaxInterval { get; }
+        /// <summary>
+        /// Level of parallelism
+        /// </summary>
+        public int Parallelism { get; }
+
+        /// <summary>
+        /// Sets max batch size
+        /// </summary>
+        public CommitterSettings WithMaxBatch(int maxBatch) => Copy(maxBatch: maxBatch);
+        /// <summary>
+        /// Sets max commit interval
+        /// </summary>
+        public CommitterSettings WithMaxInterval(TimeSpan maxInterval) => Copy(maxInterval: maxInterval);
+        /// <summary>
+        /// Sets parallelism level
+        /// </summary>
+        public CommitterSettings WithParallelism(int parallelism) => Copy(parallelism: parallelism);
+
+        private CommitterSettings Copy(int? maxBatch = null, TimeSpan? maxInterval = null, int? parallelism = null)
+        {
+            return new CommitterSettings(
+                maxBatch: maxBatch ?? MaxBatch, 
+                maxInterval: maxInterval ?? MaxInterval, 
+                parallelism: parallelism ?? Parallelism);
+        }
+    }
+}

--- a/src/Akka.Streams.Kafka/Stages/Consumers/Committers.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/Committers.cs
@@ -70,12 +70,12 @@ namespace Akka.Streams.Kafka.Stages.Consumers
             if (!(batch is CommittableOffsetBatch batchImpl))
                 throw new ArgumentException($"Unknown CommittableOffsetBatch, got {batch.GetType().FullName}, but expected {nameof(CommittableOffsetBatch)}");
             
-            await Task.WhenAll(batchImpl.OffsetsAndMetadata.GroupBy(o => o.Offset.GroupId).Select(group =>
+            await Task.WhenAll(batchImpl.OffsetsAndMetadata.GroupBy(o => o.Key.GroupId).Select(group =>
             {
                 if (!batchImpl.Committers.TryGetValue(group.Key, out var committer))
                     throw new IllegalStateException($"Unknown committer, got groupId = {group.Key}");
 
-                var offsets = group.Select(offset => offset.Offset).ToImmutableList();
+                var offsets = group.Select(offset => new GroupTopicPartitionOffset(offset.Key, offset.Value.Offset)).ToImmutableList();
                 return committer.Commit(offsets);
             }));
         }

--- a/src/Akka.Streams.Kafka/Stages/Consumers/Committers.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/Committers.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Dispatch;
+using Akka.Pattern;
 using Akka.Streams.Kafka.Messages;
 using Akka.Streams.Kafka.Stages.Consumers.Actors;
 using Akka.Streams.Kafka.Stages.Consumers.Exceptions;
@@ -20,7 +21,11 @@ namespace Akka.Streams.Kafka.Stages.Consumers
         /// <summary>
         /// Commit all offsets (of different topics) belonging to the same stage
         /// </summary>
-        Task Commit(ImmutableList<PartitionOffset> offsets);
+        Task Commit(ImmutableList<GroupTopicPartitionOffset> offsets);
+        /// <summary>
+        /// Commit offsets in batch
+        /// </summary>
+        Task Commit(ICommittableOffsetBatch batch);
     }
     
     /// <summary>
@@ -38,10 +43,8 @@ namespace Akka.Streams.Kafka.Stages.Consumers
             _consumerActor = new Lazy<IActorRef>(consumerActorFactory);
         }
 
-        /// <summary>
-        /// Commits specified offsets
-        /// </summary>
-        public Task Commit(ImmutableList<PartitionOffset> offsets)
+        /// <inheritdoc />
+        public Task Commit(ImmutableList<GroupTopicPartitionOffset> offsets)
         {
             var topicPartitionOffsets = offsets.Select(offset => new TopicPartitionOffset(offset.Topic, offset.Partition, offset.Offset + 1)).ToImmutableHashSet();
 
@@ -59,6 +62,22 @@ namespace Akka.Streams.Kafka.Stages.Consumers
                         }
                     }
                 });
+        }
+
+        /// <inheritdoc />
+        public async Task Commit(ICommittableOffsetBatch batch)
+        {
+            if (!(batch is CommittableOffsetBatch batchImpl))
+                throw new ArgumentException($"Unknown CommittableOffsetBatch, got {batch.GetType().FullName}, but expected {nameof(CommittableOffsetBatch)}");
+            
+            await Task.WhenAll(batchImpl.OffsetsAndMetadata.GroupBy(o => o.Offset.GroupId).Select(group =>
+            {
+                if (!batchImpl.Committers.TryGetValue(group.Key, out var committer))
+                    throw new IllegalStateException($"Unknown committer, got groupId = {group.Key}");
+
+                var offsets = group.Select(offset => offset.Offset).ToImmutableList();
+                return committer.Commit(offsets);
+            }));
         }
     }
 }

--- a/src/Akka.Streams.Kafka/Stages/Consumers/Concrete/SourceWithOffsetContextStage.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/Concrete/SourceWithOffsetContextStage.cs
@@ -37,7 +37,7 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Concrete
         /// <param name="subscription">Subscription to be used</param>
         /// <param name="metadataFromMessage">Function to extract string metadata from consumed message</param>
         public SourceWithOffsetContextStage(ConsumerSettings<K, V> settings, ISubscription subscription,
-                                            Func<ConsumeResult<K, V>, string> metadataFromMessage)
+                                            Func<ConsumeResult<K, V>, string> metadataFromMessage = null)
             : base("SourceWithOffsetContext")
         {
             _metadataFromMessage = metadataFromMessage ?? (msg => string.Empty);

--- a/src/Akka.Streams.Kafka/Stages/Consumers/Concrete/SourceWithOffsetContextStage.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/Concrete/SourceWithOffsetContextStage.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Threading.Tasks;
+using Akka.Streams.Kafka.Dsl;
+using Akka.Streams.Kafka.Messages;
+using Akka.Streams.Kafka.Settings;
+using Akka.Streams.Kafka.Stages.Consumers.Abstract;
+using Akka.Streams.Stage;
+using Confluent.Kafka;
+
+namespace Akka.Streams.Kafka.Stages.Consumers.Concrete
+{
+    /// <summary>
+    /// This stage is used for <see cref="KafkaConsumer.SourceWithOffsetContext{K,V}"/>
+    /// </summary>
+    /// <typeparam name="K">The key type</typeparam>
+    /// <typeparam name="V">The value type</typeparam>
+    internal class SourceWithOffsetContextStage<K, V> : KafkaSourceStage<K, V, (ConsumeResult<K, V>, ICommittableOffset)>
+    {
+        /// <summary>
+        /// Method for extracting string metadata from consumed record
+        /// </summary>
+        private readonly Func<ConsumeResult<K, V>, string> _metadataFromMessage;
+
+        /// <summary>
+        /// Consumer settings
+        /// </summary>
+        public ConsumerSettings<K, V> Settings { get; }
+        /// <summary>
+        /// Subscription
+        /// </summary>
+        public ISubscription Subscription { get; }
+
+        /// <summary>
+        /// CommittableSourceStage
+        /// </summary>
+        /// <param name="settings">Consumer settings</param>
+        /// <param name="subscription">Subscription to be used</param>
+        /// <param name="metadataFromMessage">Function to extract string metadata from consumed message</param>
+        public SourceWithOffsetContextStage(ConsumerSettings<K, V> settings, ISubscription subscription,
+                                            Func<ConsumeResult<K, V>, string> metadataFromMessage)
+            : base("SourceWithOffsetContext")
+        {
+            _metadataFromMessage = metadataFromMessage ?? (msg => string.Empty);
+            Settings = settings;
+            Subscription = subscription;
+        }
+
+        /// <inheritdoc />
+        protected override GraphStageLogic Logic(
+            SourceShape<(ConsumeResult<K, V>, ICommittableOffset)> shape,
+            TaskCompletionSource<NotUsed> completion,
+            Attributes inheritedAttributes)
+        {
+            return new SingleSourceStageLogic<K, V, (ConsumeResult<K, V>, ICommittableOffset)>(shape, Settings, Subscription, 
+                                                                                               inheritedAttributes, completion, 
+                                                                                               GetMessageBuilder);
+        }
+        
+        private OffsetContextBuilder<K, V> GetMessageBuilder(BaseSingleSourceLogic<K, V, (ConsumeResult<K, V>, ICommittableOffset)> logic)
+        {
+            var committer = new KafkaAsyncConsumerCommitter(() => logic.ConsumerActor, Settings.CommitTimeout);
+            return new OffsetContextBuilder<K, V>(committer, Settings, _metadataFromMessage);
+        }
+    }
+}

--- a/src/Akka.Streams.Kafka/Stages/Consumers/MessageBuilders.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/MessageBuilders.cs
@@ -50,7 +50,7 @@ namespace Akka.Streams.Kafka.Stages.Consumers
         /// <inheritdoc />
         public CommittableMessage<K, V> CreateMessage(ConsumeResult<K, V> record)
         {
-            var offset = new PartitionOffset(GroupId, record.Topic, record.Partition, record.Offset);
+            var offset = new GroupTopicPartitionOffset(GroupId, record.Topic, record.Partition, record.Offset);
             return new CommittableMessage<K, V>(record, new CommittableOffset(Committer, offset, MetadataFromRecord(record)));
         }
     }
@@ -115,7 +115,7 @@ namespace Akka.Streams.Kafka.Stages.Consumers
         /// <inheritdoc />
         public (ConsumeResult<K, V>, ICommittableOffset) CreateMessage(ConsumeResult<K, V> record)
         {
-            var offset = new PartitionOffset(GroupId, record.Topic, record.Partition, record.Offset);
+            var offset = new GroupTopicPartitionOffset(GroupId, record.Topic, record.Partition, record.Offset);
             return (record, new CommittableOffset(Committer, offset, _metadataFromMessage(record)));
         }
     }

--- a/src/Akka.Streams.Kafka/reference.conf
+++ b/src/Akka.Streams.Kafka/reference.conf
@@ -44,10 +44,10 @@ akka.kafka.default-dispatcher {
 # Committer flows use this settings to make batch commits
 akka.kafka.committer {
     # Set max commit batch size
-    max-batch = 2
+    max-batch = 1
     
     # Set max commit interval
-    max-interval = 100ms
+    max-interval = 1s
     
     # Set level of parallelism
     parallelism = 1

--- a/src/Akka.Streams.Kafka/reference.conf
+++ b/src/Akka.Streams.Kafka/reference.conf
@@ -40,3 +40,15 @@ akka.kafka.default-dispatcher {
   type = "Dispatcher"
   executor = "default-executor"
 }
+
+# Committer flows use this settings to make batch commits
+akka.kafka.committer {
+    # Set max commit batch size
+    max-batch = 2
+    
+    # Set max commit interval
+    max-interval = 100ms
+    
+    # Set level of parallelism
+    parallelism = 1
+}

--- a/src/Akka.Streams.Kafka/reference.conf
+++ b/src/Akka.Streams.Kafka/reference.conf
@@ -43,12 +43,12 @@ akka.kafka.default-dispatcher {
 
 # Committer flows use this settings to make batch commits
 akka.kafka.committer {
-    # Set max commit batch size
-    max-batch = 1
+    # Set maximum number of messages to commit at once
+    max-batch = 1000
     
-    # Set max commit interval
-    max-interval = 1s
+    # Set maximum interval between commits
+    max-interval = 10s
     
-    # Set level of parallelism
+    # Set parallelism for async committing
     parallelism = 1
 }


### PR DESCRIPTION
As a part of work over issue #36 , `SourceWithOffsetContext` consumer source will be implemented and tested in this PR.

This souse is basically provides another way of passing consumed messages and committable offset to downstream. The main difference (as far as I understand) is that while `CommittableSource` passes `CommittableMessage` to the downstream, forcing consequent flows to handle both message and it's committable offset, this `SourceWithOffsetContext` allows to put committable offset to the source's context.

Also, some helpers like `Committer` static class with committing flows are implemented in this PR, because they are used to make testing simpler/cleaner. 

There is one more test for this source type, but it will require one more producer flow implementation, so it will be added in one of the next PRs.