### PR TITLE
CommittableExternalSource

### DIFF
--- a/src/Akka.Streams.Kafka/Dsl/KafkaConsumer.cs
+++ b/src/Akka.Streams.Kafka/Dsl/KafkaConsumer.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Streams.Dsl;
 using Akka.Streams.Kafka.Settings;
@@ -50,6 +51,15 @@ namespace Akka.Streams.Kafka.Dsl
         public static Source<CommittableMessage<K, V>, Task> CommittableSource<K, V>(ConsumerSettings<K, V> settings, ISubscription subscription)
         {
             return Source.FromGraph(new CommittableSourceStage<K, V>(settings, subscription));
+        }
+
+        /// <summary>
+        /// The same as <see cref="PlainExternalSource{K,V}"/> but for offset commit support
+        /// </summary>
+        public static Source<CommittableMessage<K, V>, Task> CommittableExternalSource<K, V>(IActorRef consumer, IManualSubscription subscription, 
+                                                                                       string groupId, TimeSpan commitTimeout)
+        {
+            return Source.FromGraph<CommittableMessage<K, V>, Task>(new ExternalCommittableSourceStage<K, V>(consumer, groupId, commitTimeout, subscription));
         }
     }
 }

--- a/src/Akka.Streams.Kafka/Stages/Consumers/Concrete/CommittableSourceStage.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/Concrete/CommittableSourceStage.cs
@@ -57,7 +57,7 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Concrete
         private CommittableSourceMessageBuilder<K, V> GetMessageBuilder(BaseSingleSourceLogic<K, V, CommittableMessage<K, V>> logic)
         {
             var committer = new KafkaAsyncConsumerCommitter(() => logic.ConsumerActor, Settings.CommitTimeout);
-            return new CommittableSourceMessageBuilder<K, V>(committer, Settings, _metadataFromMessage);
+            return new CommittableSourceMessageBuilder<K, V>(committer, Settings.GroupId, _metadataFromMessage);
         }
     }
 }

--- a/src/Akka.Streams.Kafka/Stages/Consumers/Concrete/ExternalCommittableSourceStage.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/Concrete/ExternalCommittableSourceStage.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Event;
+using Akka.Streams.Kafka.Dsl;
+using Akka.Streams.Kafka.Messages;
+using Akka.Streams.Kafka.Settings;
+using Akka.Streams.Kafka.Stages.Consumers.Abstract;
+using Akka.Streams.Stage;
+using Confluent.Kafka;
+
+namespace Akka.Streams.Kafka.Stages.Consumers.Concrete
+{
+    /// <summary>
+    /// This stage is used for <see cref="KafkaConsumer.CommittableExternalSource{K,V}"/>
+    /// </summary>
+    /// <typeparam name="K">The key type</typeparam>
+    /// <typeparam name="V">The value type</typeparam>
+    public class ExternalCommittableSourceStage<K, V> : KafkaSourceStage<K, V, CommittableMessage<K, V>>
+    {
+        /// <summary>
+        /// Externally provided consumer
+        /// </summary>
+        public IActorRef Consumer { get; }
+        /// <summary>
+        /// Subscription
+        /// </summary>
+        public IManualSubscription Subscription { get; }
+        /// <summary>
+        /// Consumer group Id
+        /// </summary>
+        public string GroupId { get; }
+        /// <summary>
+        /// Commit timeout
+        /// </summary>
+        public TimeSpan CommitTimeout { get; }
+
+        /// <summary>
+        /// ExternalCommittableSourceStage
+        /// </summary>
+        public ExternalCommittableSourceStage(IActorRef consumer, string groupId, TimeSpan commitTimeout, IManualSubscription subscription) 
+            : base("ExternalCommittableSource")
+        {
+            Consumer = consumer;
+            GroupId = groupId;
+            CommitTimeout = commitTimeout;
+            Subscription = subscription;
+        }
+
+        /// <inheritdoc />
+        protected override GraphStageLogic Logic(SourceShape<CommittableMessage<K, V>> shape, TaskCompletionSource<NotUsed> completion, Attributes inheritedAttributes)
+        {
+            return new ExternalSingleSourceLogic<K, V, CommittableMessage<K, V>>(shape, Consumer, Subscription, completion, inheritedAttributes, GetMessageBuilder);
+        }
+        
+        private CommittableSourceMessageBuilder<K, V> GetMessageBuilder(BaseSingleSourceLogic<K, V, CommittableMessage<K, V>> logic)
+        {
+            var committer = new KafkaAsyncConsumerCommitter(() => logic.ConsumerActor, CommitTimeout);
+            return new CommittableSourceMessageBuilder<K, V>(committer, GroupId, m => string.Empty);
+        }
+    }
+}

--- a/src/Akka.Streams.Kafka/Stages/Consumers/MessageBuilders.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/MessageBuilders.cs
@@ -60,26 +60,24 @@ namespace Akka.Streams.Kafka.Stages.Consumers
     /// </summary>
     internal class CommittableSourceMessageBuilder<K, V> : CommittableMessageBuilderBase<K, V>
     {
-        private readonly IInternalCommitter _committer;
-        private readonly ConsumerSettings<K, V> _settings;
         private readonly Func<ConsumeResult<K, V>, string> _metadataFromRecord;
+        
+        /// <inheritdoc />
+        public override IInternalCommitter Committer { get; }
+
+        /// <inheritdoc />
+        public override string GroupId { get; }
 
         /// <summary>
         /// CommittableSourceMessageBuilder
         /// </summary>
-        public CommittableSourceMessageBuilder(IInternalCommitter committer, ConsumerSettings<K, V> settings, Func<ConsumeResult<K, V>, string> metadataFromRecord)
+        public CommittableSourceMessageBuilder(IInternalCommitter committer, string groupId, Func<ConsumeResult<K, V>, string> metadataFromRecord)
         {
-            _committer = committer;
-            _settings = settings;
+            Committer = committer;
+            GroupId = groupId;
             _metadataFromRecord = metadataFromRecord;
         }
-
-        /// <inheritdoc />
-        public override IInternalCommitter Committer => _committer;
-
-        /// <inheritdoc />
-        public override string GroupId => _settings.GroupId;
-
+        
         /// <inheritdoc />
         public override string MetadataFromRecord(ConsumeResult<K, V> record) => _metadataFromRecord(record);
     }


### PR DESCRIPTION
This PR is part of work over issue #36 and implements `CommittableExternalSource`.

This source is pretty simple and does the same thing as `PlainExternalSource`, but with committable messages - it uses some pre-existing consuming actor to consume/commit messages.

PR will be in draft stage until I will add tests for this new source.