### PR TITLE
IControl implementation

### DIFF
--- a/src/Akka.Streams.Kafka.Tests/Integration/AtMostOnceSourceIntegrationTests.cs
+++ b/src/Akka.Streams.Kafka.Tests/Integration/AtMostOnceSourceIntegrationTests.cs
@@ -26,13 +26,13 @@ namespace Akka.Streams.Kafka.Tests.Integration
 
             await ProduceStrings(topic, Enumerable.Range(1, 10), ProducerSettings);
             
-            var (task, result) = KafkaConsumer.AtMostOnceSource(CreateConsumerSettings<string>(group), Subscriptions.Topics(topic))
+            var (control, result) = KafkaConsumer.AtMostOnceSource(CreateConsumerSettings<string>(group), Subscriptions.Topics(topic))
                 .Select(m => m.Value)
                 .Take(5)
                 .ToMaterialized(Sink.Seq<string>(), Keep.Both)
                 .Run(Materializer);
             
-            AwaitCondition(() => task.IsCompletedSuccessfully, TimeSpan.FromSeconds(10));
+            AwaitCondition(() => control.IsShutdown.IsCompletedSuccessfully, TimeSpan.FromSeconds(10));
             
             result.Result.Should().BeEquivalentTo(Enumerable.Range(1, 5).Select(i => i.ToString()));
         }

--- a/src/Akka.Streams.Kafka.Tests/Integration/CommitWithMetadataSourceIntegrationTests.cs
+++ b/src/Akka.Streams.Kafka.Tests/Integration/CommitWithMetadataSourceIntegrationTests.cs
@@ -37,7 +37,7 @@ namespace Akka.Streams.Kafka.Tests.Integration
 
             await ProduceStrings(topic, Enumerable.Range(1, 10), ProducerSettings);
             
-            var (task, probe) = KafkaConsumer.CommitWithMetadataSource(CreateConsumerSettings<string>(group), Subscriptions.Topics(topic), MetadataFromMessage)
+            var (control, probe) = KafkaConsumer.CommitWithMetadataSource(CreateConsumerSettings<string>(group), Subscriptions.Topics(topic), MetadataFromMessage)
                 .ToMaterialized(this.SinkProbe<CommittableMessage<Null, string>>(), Keep.Both)
                 .Run(Materializer);
 
@@ -52,7 +52,7 @@ namespace Akka.Streams.Kafka.Tests.Integration
 
             probe.Cancel();
             
-            AwaitCondition(() => task.IsCompletedSuccessfully, TimeSpan.FromSeconds(10));
+            AwaitCondition(() => control.IsShutdown.IsCompletedSuccessfully, TimeSpan.FromSeconds(10));
         }
     }
 }

--- a/src/Akka.Streams.Kafka.Tests/Integration/CommittableSourceIntegrationTests.cs
+++ b/src/Akka.Streams.Kafka.Tests/Integration/CommittableSourceIntegrationTests.cs
@@ -91,7 +91,7 @@ namespace Akka.Streams.Kafka.Tests.Integration
                 
             probe1.Cancel();
 
-            AwaitCondition(() => task.IsCompletedSuccessfully);
+            AwaitCondition(() => task.IsShutdown.IsCompletedSuccessfully);
 
             var probe2 = KafkaConsumer.CommittableSource(consumerSettings, Subscriptions.Assignment(new TopicPartition(topic1, 0)))
                 .Select(_ => _.Record.Value)

--- a/src/Akka.Streams.Kafka.Tests/Integration/SourceWithOffsetContextIntegrationTests.cs
+++ b/src/Akka.Streams.Kafka.Tests/Integration/SourceWithOffsetContextIntegrationTests.cs
@@ -33,7 +33,7 @@ namespace Akka.Streams.Kafka.Tests.Integration
 
             var committerSettings = CommitterSettings.WithMaxBatch(batchSize);
             
-            var (task, probe) = KafkaConsumer.SourceWithOffsetContext(settings, Subscriptions.Topics(topic))
+            var (control, probe) = KafkaConsumer.SourceWithOffsetContext(settings, Subscriptions.Topics(topic))
                 .SelectAsync(10, message => Task.FromResult(Done.Instance))
                 .Via(Committer.FlowWithOffsetContext<Done>(committerSettings))
                 .AsSource()
@@ -45,7 +45,7 @@ namespace Akka.Streams.Kafka.Tests.Integration
 
             probe.Cancel();
             
-            AwaitCondition(() => task.IsCompletedSuccessfully, TimeSpan.FromSeconds(10));
+            AwaitCondition(() => control.IsShutdown.IsCompletedSuccessfully, TimeSpan.FromSeconds(10));
 
             committedBatches.Select(r => r.Item2).Sum(batch => batch.BatchSize).Should().Be(10);
         }

--- a/src/Akka.Streams.Kafka.Tests/KafkaIntegrationTests.cs
+++ b/src/Akka.Streams.Kafka.Tests/KafkaIntegrationTests.cs
@@ -5,6 +5,7 @@ using Akka.Actor;
 using Akka.Configuration;
 using Akka.Streams.Dsl;
 using Akka.Streams.Kafka.Dsl;
+using Akka.Streams.Kafka.Helpers;
 using Akka.Streams.Kafka.Messages;
 using Akka.Streams.Kafka.Settings;
 using Akka.Streams.TestKit;
@@ -90,7 +91,7 @@ namespace Akka.Streams.Kafka.Tests
             }
         }
         
-        protected Tuple<Task, TestSubscriber.Probe<TValue>> CreateExternalPlainSourceProbe<TValue>(IActorRef consumer, IManualSubscription sub)
+        protected Tuple<IControl, TestSubscriber.Probe<TValue>> CreateExternalPlainSourceProbe<TValue>(IActorRef consumer, IManualSubscription sub)
         {
             return KafkaConsumer
                 .PlainExternalSource<Null, TValue>(consumer, sub)

--- a/src/Akka.Streams.Kafka.Tests/TestsConfiguration.cs
+++ b/src/Akka.Streams.Kafka.Tests/TestsConfiguration.cs
@@ -18,6 +18,6 @@ namespace Akka.Streams.Kafka.Tests
         /// <remarks>
         /// When this option is enabled, use docker-compose to start kafka manually (see docker-compose.yml file in the root folder)
         /// </remarks>
-        public static readonly bool UseExistingDockerContainer = Environment.GetEnvironmentVariable("AKKA_STREAMS_KAFKA_TEST_CONTAINER_REUSE") != null;
+        public static readonly bool UseExistingDockerContainer = false && Environment.GetEnvironmentVariable("AKKA_STREAMS_KAFKA_TEST_CONTAINER_REUSE") != null;
     }
 }

--- a/src/Akka.Streams.Kafka.Tests/TestsConfiguration.cs
+++ b/src/Akka.Streams.Kafka.Tests/TestsConfiguration.cs
@@ -18,6 +18,6 @@ namespace Akka.Streams.Kafka.Tests
         /// <remarks>
         /// When this option is enabled, use docker-compose to start kafka manually (see docker-compose.yml file in the root folder)
         /// </remarks>
-        public static readonly bool UseExistingDockerContainer = false && Environment.GetEnvironmentVariable("AKKA_STREAMS_KAFKA_TEST_CONTAINER_REUSE") != null;
+        public static readonly bool UseExistingDockerContainer = Environment.GetEnvironmentVariable("AKKA_STREAMS_KAFKA_TEST_CONTAINER_REUSE") != null;
     }
 }

--- a/src/Akka.Streams.Kafka/Dsl/KafkaConsumer.cs
+++ b/src/Akka.Streams.Kafka/Dsl/KafkaConsumer.cs
@@ -28,7 +28,7 @@ namespace Akka.Streams.Kafka.Dsl
         /// possible, but when it is, it will make the consumption fully atomic and give "exactly once" semantics that are
         /// stronger than the "at-least once" semantics you get with Kafka's offset commit functionality.
         /// </summary>
-        public static Source<ConsumeResult<K, V>, Task> PlainSource<K, V>(ConsumerSettings<K, V> settings, ISubscription subscription)
+        public static Source<ConsumeResult<K, V>, IControl> PlainSource<K, V>(ConsumerSettings<K, V> settings, ISubscription subscription)
         {
             return Source.FromGraph(new PlainSourceStage<K, V>(settings, subscription));
         }
@@ -37,7 +37,7 @@ namespace Akka.Streams.Kafka.Dsl
         /// Special source that can use an external `KafkaAsyncConsumer`. This is useful when you have
         /// a lot of manually assigned topic-partitions and want to keep only one kafka consumer.
         /// </summary>
-        public static Source<ConsumeResult<K, V>, Task> PlainExternalSource<K, V>(IActorRef consumer, IManualSubscription subscription)
+        public static Source<ConsumeResult<K, V>, IControl> PlainExternalSource<K, V>(IActorRef consumer, IManualSubscription subscription)
         {
             return Source.FromGraph(new ExternalPlainSourceStage<K, V>(consumer, subscription));
         }
@@ -50,7 +50,7 @@ namespace Akka.Streams.Kafka.Dsl
         /// If you need to store offsets in anything other than Kafka, <see cref="PlainSource{K,V}"/> should
         /// be used instead of this API.
         /// </summary>
-        public static Source<CommittableMessage<K, V>, Task> CommittableSource<K, V>(ConsumerSettings<K, V> settings, ISubscription subscription)
+        public static Source<CommittableMessage<K, V>, IControl> CommittableSource<K, V>(ConsumerSettings<K, V> settings, ISubscription subscription)
         {
             return Source.FromGraph(new CommittableSourceStage<K, V>(settings, subscription));
         }
@@ -60,7 +60,7 @@ namespace Akka.Streams.Kafka.Dsl
         /// when an offset is committed based on the record. This can be useful (for example) to store information about which
         /// node made the commit, what time the commit was made, the timestamp of the record etc.
         /// </summary>
-        public static Source<CommittableMessage<K, V>, Task> CommitWithMetadataSource<K, V>(ConsumerSettings<K, V> settings, ISubscription subscription,
+        public static Source<CommittableMessage<K, V>, IControl> CommitWithMetadataSource<K, V>(ConsumerSettings<K, V> settings, ISubscription subscription,
                                                                                             Func<ConsumeResult<K, V>, string> metadataFromRecord)
         {
             return Source.FromGraph(new CommittableSourceStage<K, V>(settings, subscription, metadataFromRecord));
@@ -78,7 +78,7 @@ namespace Akka.Streams.Kafka.Dsl
         /// <see cref="KafkaProducer.FlowWithContext{K,V,C}"/> and/or <see cref="Committer.SinkWithOffsetContext{E}"/>
         /// </summary>
         [ApiMayChange]
-        public static SourceWithContext<ICommittableOffset, ConsumeResult<K, V>, Task> SourceWithOffsetContext<K, V>(
+        public static SourceWithContext<ICommittableOffset, ConsumeResult<K, V>, IControl> SourceWithOffsetContext<K, V>(
             ConsumerSettings<K, V> settings, ISubscription subscription, Func<ConsumeResult<K, V>, string> metadataFromRecord = null)
         {
             return Source.FromGraph(new SourceWithOffsetContextStage<K, V>(settings, subscription, metadataFromRecord))
@@ -89,17 +89,17 @@ namespace Akka.Streams.Kafka.Dsl
         /// <summary>
         /// The same as <see cref="PlainExternalSource{K,V}"/> but for offset commit support
         /// </summary>
-        public static Source<CommittableMessage<K, V>, Task> CommittableExternalSource<K, V>(IActorRef consumer, IManualSubscription subscription, 
+        public static Source<CommittableMessage<K, V>, IControl> CommittableExternalSource<K, V>(IActorRef consumer, IManualSubscription subscription, 
                                                                                        string groupId, TimeSpan commitTimeout)
         {
-            return Source.FromGraph<CommittableMessage<K, V>, Task>(new ExternalCommittableSourceStage<K, V>(consumer, groupId, commitTimeout, subscription));
+            return Source.FromGraph<CommittableMessage<K, V>, IControl>(new ExternalCommittableSourceStage<K, V>(consumer, groupId, commitTimeout, subscription));
         }
 
         /// <summary>
         /// Convenience for "at-most once delivery" semantics.
         /// The offset of each message is committed to Kafka before being emitted downstream.
         /// </summary>
-        public static Source<ConsumeResult<K, V>, Task> AtMostOnceSource<K, V>(ConsumerSettings<K, V> settings, ISubscription subscription)
+        public static Source<ConsumeResult<K, V>, IControl> AtMostOnceSource<K, V>(ConsumerSettings<K, V> settings, ISubscription subscription)
         {
             return CommittableSource(settings, subscription).SelectAsync(1, async message =>
             {

--- a/src/Akka.Streams.Kafka/Extensions/ControlExtensions.cs
+++ b/src/Akka.Streams.Kafka/Extensions/ControlExtensions.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Threading.Tasks;
+using Akka.Streams.Kafka.Helpers;
+
+namespace Akka.Streams.Kafka.Extensions
+{
+    /// <summary>
+    /// ControlExtensions
+    /// </summary>
+    public static class ControlExtensions
+    {
+        /// <summary>
+        /// Stop producing messages from the `Source`, wait for stream completion
+        /// and shut down the consumer `Source` so that all consumed messages
+        /// reach the end of the stream.
+        /// Failures in stream completion will be propagated, the source will be shut down anyway.
+        /// </summary>
+        public static async Task<TResult> DrainAndShutdownDefault<TResult>(this IControl control, Task<TResult> streamCompletion)
+        {
+            TResult result;
+            
+            try
+            {
+                await control.Stop();
+
+                result = await streamCompletion;
+            }
+            catch (Exception completionError)
+            {
+                try
+                {
+                    await control.Shutdown();
+
+                    return await streamCompletion;
+                }
+                catch (Exception)
+                {
+                    throw completionError;
+                }
+            }
+
+            await control.Shutdown();
+
+            return result;
+        }
+    }
+}

--- a/src/Akka.Streams.Kafka/Helpers/Control.cs
+++ b/src/Akka.Streams.Kafka/Helpers/Control.cs
@@ -29,7 +29,7 @@ namespace Akka.Streams.Kafka.Helpers
         /// and the underlying <see cref="IConsumer{TKey,TValue}"/> has been closed. Shutdown can be triggered
         /// from downstream cancellation, errors, or <see cref="Shutdown"/>
         /// </summary>
-        Task IsShutdown();
+        Task IsShutdown { get; }
 
         /// <summary>
         /// Stop producing messages from the `Source`, wait for stream completion
@@ -68,7 +68,7 @@ namespace Akka.Streams.Kafka.Helpers
         public Task Shutdown() => Control.Shutdown();
 
         /// <inheritdoc />
-        public Task IsShutdown() => Control.IsShutdown();
+        public Task IsShutdown => Control.IsShutdown;
 
         /// <inheritdoc />
         public Task<TResult> DrainAndShutdown<TResult>(Task<TResult> streamCompletion) => Control.DrainAndShutdown(streamCompletion);
@@ -102,7 +102,7 @@ namespace Akka.Streams.Kafka.Helpers
         public Task Shutdown() => Task.FromException(Exception);
 
         /// <inheritdoc />
-        public Task IsShutdown() => Task.FromException(Exception);
+        public Task IsShutdown => Task.FromException(Exception);
 
         /// <inheritdoc />
         public Task<TResult> DrainAndShutdown<TResult>(Task<TResult> streamCompletion) => this.DrainAndShutdownDefault(streamCompletion);

--- a/src/Akka.Streams.Kafka/Helpers/Control.cs
+++ b/src/Akka.Streams.Kafka/Helpers/Control.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Threading.Tasks;
+using Akka.Streams.Kafka.Extensions;
+using Confluent.Kafka;
+
+namespace Akka.Streams.Kafka.Helpers
+{
+    /// <summary>
+    /// Materialized value of the consumer `Source`.
+    /// </summary>
+    public interface IControl
+    {
+        /// <summary>
+        /// Stop producing messages from the `Source`. This does not stop the underlying kafka consumer
+        /// and does not unsubscribe from any topics/partitions.
+        ///
+        /// Call <see cref="Shutdown"/> to close consumer.
+        /// </summary>
+        Task Stop();
+
+        /// <summary>
+        /// Shutdown the consumer `Source`. It will wait for outstanding offset
+        /// commit requests to finish before shutting down.
+        /// </summary>
+        Task Shutdown();
+
+        /// <summary>
+        /// Shutdown status. The task will be completed when the stage has been shut down
+        /// and the underlying <see cref="IConsumer{TKey,TValue}"/> has been closed. Shutdown can be triggered
+        /// from downstream cancellation, errors, or <see cref="Shutdown"/>
+        /// </summary>
+        Task IsShutdown();
+
+        /// <summary>
+        /// Stop producing messages from the `Source`, wait for stream completion
+        /// and shut down the consumer `Source` so that all consumed messages
+        /// reach the end of the stream.
+        /// Failures in stream completion will be propagated, the source will be shut down anyway.
+        /// </summary>
+        Task<TResult> DrainAndShutdown<TResult>(Task<TResult> streamCompletion);
+    }
+
+    /// <summary>
+    /// Combine control and a stream completion signal materialized values into
+    /// one, so that the stream can be stopped in a controlled way without losing
+    /// commits.
+    /// </summary>
+    public class DrainingControl<T> : IControl
+    {
+        public IControl Control { get; }
+        public Task<T> StreamCompletion { get; }
+
+        /// <summary>
+        /// DrainingControl
+        /// </summary>
+        /// <param name="control"></param>
+        /// <param name="streamCompletion"></param>
+        private DrainingControl(IControl control, Task<T> streamCompletion)
+        {
+            Control = control;
+            StreamCompletion = streamCompletion;
+        }
+
+        /// <inheritdoc />
+        public Task Stop() => Control.Stop();
+
+        /// <inheritdoc />
+        public Task Shutdown() => Control.Shutdown();
+
+        /// <inheritdoc />
+        public Task IsShutdown() => Control.IsShutdown();
+
+        /// <inheritdoc />
+        public Task<TResult> DrainAndShutdown<TResult>(Task<TResult> streamCompletion) => Control.DrainAndShutdown(streamCompletion);
+
+        /// <summary>
+        /// Stop producing messages from the `Source`, wait for stream completion
+        /// and shut down the consumer `Source` so that all consumed messages
+        /// reach the end of the stream.
+        /// </summary>
+        public Task<T> DrainAndShutdown(Task<T> streamCompletion) => Control.DrainAndShutdownDefault(StreamCompletion);
+        
+        /// <summary>
+        /// Combine control and a stream completion signal materialized values into
+        /// one, so that the stream can be stopped in a controlled way without losing
+        /// commits.
+        /// </summary>
+        public static DrainingControl<T> Create(IControl control, Task<T> streamCompletion) => new DrainingControl<T>(control, streamCompletion);
+    }
+
+    /// <summary>
+    /// An implementation of Control to be used as an empty value, all methods return a failed task.
+    /// </summary>
+    public class NoopControl : IControl
+    {
+        private static Exception Exception => new Exception("The correct Consumer.Control has not been assigned, yet.");
+
+        /// <inheritdoc />
+        public Task Stop() => Task.FromException(Exception);
+
+        /// <inheritdoc />
+        public Task Shutdown() => Task.FromException(Exception);
+
+        /// <inheritdoc />
+        public Task IsShutdown() => Task.FromException(Exception);
+
+        /// <inheritdoc />
+        public Task<TResult> DrainAndShutdown<TResult>(Task<TResult> streamCompletion) => this.DrainAndShutdownDefault(streamCompletion);
+    }
+}

--- a/src/Akka.Streams.Kafka/Helpers/PromiseControl.cs
+++ b/src/Akka.Streams.Kafka/Helpers/PromiseControl.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Threading.Tasks;
+using Akka.Streams.Kafka.Extensions;
+
+namespace Akka.Streams.Kafka.Helpers
+{
+    /// <summary>
+    /// Used in source logic classes to provide <see cref="IControl"/> implementation.
+    /// </summary>
+    /// <typeparam name="TSourceOut"></typeparam>
+    class PromiseControl<TSourceOut> : IControl
+    {
+        private readonly SourceShape<TSourceOut> _shape;
+        private readonly Action<Outlet<TSourceOut>> _completeStageOutlet;
+        private readonly Action<bool> _setStageKeepGoing;
+        
+        private readonly TaskCompletionSource<Done> _shutdownTaskSource = new TaskCompletionSource<Done>();
+        private readonly TaskCompletionSource<Done> _stopTaskSource = new TaskCompletionSource<Done>();
+        private readonly Action _stopCallback;
+        private readonly Action _shutdownCallback;
+
+        public PromiseControl(SourceShape<TSourceOut> shape, Action<Outlet<TSourceOut>> completeStageOutlet, 
+                              Action<bool> setStageKeepGoing,  Func<Action, Action> asyncCallbackFactory)
+        {
+            _shape = shape;
+            _completeStageOutlet = completeStageOutlet;
+            _setStageKeepGoing = setStageKeepGoing;
+
+            _stopCallback = asyncCallbackFactory(PerformStop);
+            _shutdownCallback = asyncCallbackFactory(PerformShutdown);
+        }
+
+        /// <inheritdoc />
+        public Task Stop()
+        {
+            _stopCallback();
+            return _stopTaskSource.Task;
+        }
+
+        /// <inheritdoc />
+        public Task Shutdown()
+        {
+            _shutdownCallback();
+            return _shutdownTaskSource.Task;
+        }
+
+        /// <inheritdoc />
+        public Task IsShutdown() => _shutdownTaskSource.Task;
+
+        /// <inheritdoc />
+        public Task<TResult> DrainAndShutdown<TResult>(Task<TResult> streamCompletion) => this.DrainAndShutdownDefault(streamCompletion);
+
+        /// <summary>
+        /// Performs source logic stop
+        /// </summary>
+        public virtual void PerformStop()
+        {
+            _setStageKeepGoing(true);
+            _completeStageOutlet(_shape.Outlet);
+            OnStop();
+        }
+
+        /// <summary>
+        /// Performs source logic shutdown
+        /// </summary>
+        public virtual void PerformShutdown()
+        {
+        }
+
+        /// <summary>
+        /// Executed on source logic stop
+        /// </summary>
+        public void OnStop()
+        {
+            _stopTaskSource.TrySetResult(Done.Instance);
+        }
+
+        /// <summary>
+        /// Executed on source logic shutdown
+        /// </summary>
+        public void OnShutdown()
+        {
+            _stopTaskSource.TrySetResult(Done.Instance);
+            _shutdownTaskSource.TrySetResult(Done.Instance);
+        }
+    }
+}

--- a/src/Akka.Streams.Kafka/Helpers/PromiseControl.cs
+++ b/src/Akka.Streams.Kafka/Helpers/PromiseControl.cs
@@ -9,7 +9,7 @@ namespace Akka.Streams.Kafka.Helpers
     /// Used in source logic classes to provide <see cref="IControl"/> implementation.
     /// </summary>
     /// <typeparam name="TSourceOut"></typeparam>
-    class PromiseControl<TSourceOut> : IControl
+    internal class PromiseControl<TSourceOut> : IControl
     {
         private readonly SourceShape<TSourceOut> _shape;
         private readonly Action<Outlet<TSourceOut>> _completeStageOutlet;

--- a/src/Akka.Streams.Kafka/Helpers/PromiseControl.cs
+++ b/src/Akka.Streams.Kafka/Helpers/PromiseControl.cs
@@ -14,7 +14,6 @@ namespace Akka.Streams.Kafka.Helpers
         private readonly SourceShape<TSourceOut> _shape;
         private readonly Action<Outlet<TSourceOut>> _completeStageOutlet;
         private readonly Action<bool> _setStageKeepGoing;
-        private readonly Option<Action> _performShutdown;
 
         private readonly TaskCompletionSource<Done> _shutdownTaskSource = new TaskCompletionSource<Done>();
         private readonly TaskCompletionSource<Done> _stopTaskSource = new TaskCompletionSource<Done>();
@@ -22,13 +21,11 @@ namespace Akka.Streams.Kafka.Helpers
         private readonly Action _shutdownCallback;
 
         public PromiseControl(SourceShape<TSourceOut> shape, Action<Outlet<TSourceOut>> completeStageOutlet, 
-                              Action<bool> setStageKeepGoing,  Func<Action, Action> asyncCallbackFactory,
-                              Option<Action> performShutdown)
+                              Action<bool> setStageKeepGoing,  Func<Action, Action> asyncCallbackFactory)
         {
             _shape = shape;
             _completeStageOutlet = completeStageOutlet;
             _setStageKeepGoing = setStageKeepGoing;
-            _performShutdown = performShutdown;
 
             _stopCallback = asyncCallbackFactory(PerformStop);
             _shutdownCallback = asyncCallbackFactory(PerformShutdown);
@@ -69,8 +66,6 @@ namespace Akka.Streams.Kafka.Helpers
         /// </summary>
         public virtual void PerformShutdown()
         {
-            if (_performShutdown.HasValue)
-                _performShutdown.Value.Invoke();
         }
 
         /// <summary>

--- a/src/Akka.Streams.Kafka/Stages/Consumers/Abstract/ExternalSingleSourceLogic.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/Abstract/ExternalSingleSourceLogic.cs
@@ -18,9 +18,9 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
         private readonly IManualSubscription _subscription;
 
         public ExternalSingleSourceLogic(SourceShape<TMessage> shape, IActorRef consumerActor, IManualSubscription subscription,
-                                         TaskCompletionSource<NotUsed> completion, Attributes attributes, 
+                                         Attributes attributes, 
                                          Func<BaseSingleSourceLogic<K, V, TMessage>, IMessageBuilder<K, V, TMessage>> messageBuilderFactory) 
-            : base(shape, completion, attributes, messageBuilderFactory)
+            : base(shape, attributes, messageBuilderFactory)
         {
             _consumerActor = consumerActor;
             _subscription = subscription;

--- a/src/Akka.Streams.Kafka/Stages/Consumers/Abstract/KafkaSourceStage.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/Abstract/KafkaSourceStage.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using Akka.Streams.Kafka.Helpers;
 using Akka.Streams.Stage;
 
 namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
@@ -12,7 +13,7 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
     /// <typeparam name="K">Key type</typeparam>
     /// <typeparam name="V">Value type</typeparam>
     /// <typeparam name="TMessage">Stage output messages type</typeparam>
-    public abstract class KafkaSourceStage<K, V, TMessage> : GraphStageWithMaterializedValue<SourceShape<TMessage>, Task>
+    public abstract class KafkaSourceStage<K, V, TMessage> : GraphStageWithMaterializedValue<SourceShape<TMessage>, IControl>
     {
         /// <summary>
         /// Name of the stage
@@ -44,17 +45,15 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
         /// Provides actual stage logic
         /// </summary>
         /// <param name="shape">Shape of the stage</param>
-        /// <param name="completion">Used to specify stage task completion</param>
         /// <param name="inheritedAttributes">Stage attributes</param>
         /// <returns>Stage logic</returns>
-        protected abstract GraphStageLogic Logic(SourceShape<TMessage> shape, TaskCompletionSource<NotUsed> completion, Attributes inheritedAttributes);
+        protected abstract (GraphStageLogic, IControl) Logic(SourceShape<TMessage> shape, Attributes inheritedAttributes);
 
         /// <inheritdoc />
-        public override ILogicAndMaterializedValue<Task> CreateLogicAndMaterializedValue(Attributes inheritedAttributes)
+        public override ILogicAndMaterializedValue<IControl> CreateLogicAndMaterializedValue(Attributes inheritedAttributes)
         {
-            var completion = new TaskCompletionSource<NotUsed>();
-            var result = Logic(Shape, completion, inheritedAttributes);
-            return new LogicAndMaterializedValue<Task>(result, completion.Task);
+            var (logic, materializedValue) = Logic(Shape, inheritedAttributes);
+            return new LogicAndMaterializedValue<IControl>(logic, materializedValue);
         }
     }
 }

--- a/src/Akka.Streams.Kafka/Stages/Consumers/Abstract/SingleSourceStageLogic.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/Abstract/SingleSourceStageLogic.cs
@@ -104,7 +104,7 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
             switch (args.Item2)
             {
                 case Terminated terminated when terminated.ActorRef.Equals(ConsumerActor):
-                    InternalControl.OnShutdown();
+                    Control.OnShutdown();
                     CompleteStage();
                     break;
                 default:

--- a/src/Akka.Streams.Kafka/Stages/Consumers/Abstract/SingleSourceStageLogic.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/Abstract/SingleSourceStageLogic.cs
@@ -27,9 +27,8 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
 
         public SingleSourceStageLogic(SourceShape<TMessage> shape, ConsumerSettings<K, V> settings, 
                                       ISubscription subscription, Attributes attributes, 
-                                      TaskCompletionSource<NotUsed> completion, 
                                       Func<BaseSingleSourceLogic<K, V, TMessage>, IMessageBuilder<K, V, TMessage>> messageBuilderFactory) 
-            : base(shape, completion, attributes, messageBuilderFactory)
+            : base(shape, attributes, messageBuilderFactory)
         {
             _shape = shape;
             _settings = settings;
@@ -105,7 +104,7 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
             switch (args.Item2)
             {
                 case Terminated terminated when terminated.ActorRef.Equals(ConsumerActor):
-                    OnShutdown();
+                    InternalControl.OnShutdown();
                     CompleteStage();
                     break;
                 default:

--- a/src/Akka.Streams.Kafka/Stages/Consumers/Concrete/CommittableSourceStage.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/Concrete/CommittableSourceStage.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
 using Akka.Streams.Kafka.Dsl;
+using Akka.Streams.Kafka.Helpers;
 using Akka.Streams.Kafka.Messages;
 using Akka.Streams.Kafka.Settings;
 using Akka.Streams.Kafka.Stages.Consumers.Abstract;
@@ -46,12 +47,12 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Concrete
         /// Provides actual stage logic
         /// </summary>
         /// <param name="shape">Shape of the stage</param>
-        /// <param name="completion">Used to specify stage task completion</param>
         /// <param name="inheritedAttributes">Stage attributes</param>
         /// <returns>Stage logic</returns>
-        protected override GraphStageLogic Logic(SourceShape<CommittableMessage<K, V>> shape, TaskCompletionSource<NotUsed> completion, Attributes inheritedAttributes)
+        protected override (GraphStageLogic, IControl) Logic(SourceShape<CommittableMessage<K, V>> shape, Attributes inheritedAttributes)
         { 
-            return new SingleSourceStageLogic<K, V, CommittableMessage<K, V>>(shape, Settings, Subscription, inheritedAttributes, completion, GetMessageBuilder);
+            var logic = new SingleSourceStageLogic<K, V, CommittableMessage<K, V>>(shape, Settings, Subscription, inheritedAttributes, GetMessageBuilder);
+            return (logic, logic.Control);
         }
 
         private CommittableSourceMessageBuilder<K, V> GetMessageBuilder(BaseSingleSourceLogic<K, V, CommittableMessage<K, V>> logic)

--- a/src/Akka.Streams.Kafka/Stages/Consumers/Concrete/ExternalCommittableSourceStage.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/Concrete/ExternalCommittableSourceStage.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Event;
 using Akka.Streams.Kafka.Dsl;
+using Akka.Streams.Kafka.Helpers;
 using Akka.Streams.Kafka.Messages;
 using Akka.Streams.Kafka.Settings;
 using Akka.Streams.Kafka.Stages.Consumers.Abstract;
@@ -48,9 +49,11 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Concrete
         }
 
         /// <inheritdoc />
-        protected override GraphStageLogic Logic(SourceShape<CommittableMessage<K, V>> shape, TaskCompletionSource<NotUsed> completion, Attributes inheritedAttributes)
+        protected override (GraphStageLogic, IControl) Logic(SourceShape<CommittableMessage<K, V>> shape, Attributes inheritedAttributes)
         {
-            return new ExternalSingleSourceLogic<K, V, CommittableMessage<K, V>>(shape, Consumer, Subscription, completion, inheritedAttributes, GetMessageBuilder);
+            var logic = new ExternalSingleSourceLogic<K, V, CommittableMessage<K, V>>(shape, Consumer, Subscription, inheritedAttributes, GetMessageBuilder);
+
+            return (logic, logic.Control);
         }
         
         private CommittableSourceMessageBuilder<K, V> GetMessageBuilder(BaseSingleSourceLogic<K, V, CommittableMessage<K, V>> logic)

--- a/src/Akka.Streams.Kafka/Stages/Consumers/Concrete/ExternalPlainSourceStage.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/Concrete/ExternalPlainSourceStage.cs
@@ -1,5 +1,6 @@
 using System.Threading.Tasks;
 using Akka.Actor;
+using Akka.Streams.Kafka.Helpers;
 using Akka.Streams.Kafka.Settings;
 using Akka.Streams.Kafka.Stages.Consumers.Abstract;
 using Akka.Streams.Kafka.Stages.Consumers.Actors;
@@ -37,10 +38,12 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Concrete
         }
 
         /// <inheritdoc />
-        protected override GraphStageLogic Logic(SourceShape<ConsumeResult<K, V>> shape, TaskCompletionSource<NotUsed> completion, Attributes inheritedAttributes)
+        protected override (GraphStageLogic, IControl) Logic(SourceShape<ConsumeResult<K, V>> shape, Attributes inheritedAttributes)
         {
-            return new ExternalSingleSourceLogic<K, V, ConsumeResult<K, V>>(shape, Consumer, Subscription, completion, 
-                                                                            inheritedAttributes, _ => new PlainMessageBuilder<K, V>());
+            var logic = new ExternalSingleSourceLogic<K, V, ConsumeResult<K, V>>(shape, Consumer, Subscription,
+                                                                                 inheritedAttributes, _ => new PlainMessageBuilder<K, V>());
+
+            return (logic, logic.Control);
         }
     }
 }

--- a/src/Akka.Streams.Kafka/Stages/Consumers/Concrete/PlainSourceStage.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/Concrete/PlainSourceStage.cs
@@ -1,5 +1,6 @@
 using System.Threading.Tasks;
 using Akka.Streams.Kafka.Dsl;
+using Akka.Streams.Kafka.Helpers;
 using Akka.Streams.Kafka.Settings;
 using Akka.Streams.Kafka.Stages.Consumers.Abstract;
 using Akka.Streams.Stage;
@@ -39,13 +40,13 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Concrete
         /// Provides actual stage logic
         /// </summary>
         /// <param name="shape">Shape of the stage</param>
-        /// <param name="completion">Used to specify stage task completion</param>
         /// <param name="inheritedAttributes">Stage attributes</param>
         /// <returns>Stage logic</returns>
-        protected override GraphStageLogic Logic(SourceShape<ConsumeResult<K, V>> shape, TaskCompletionSource<NotUsed> completion, Attributes inheritedAttributes)
+        protected override (GraphStageLogic, IControl) Logic(SourceShape<ConsumeResult<K, V>> shape, Attributes inheritedAttributes)
         {
-            return new SingleSourceStageLogic<K, V, ConsumeResult<K, V>>(shape, Settings, Subscription, inheritedAttributes, 
-                                                                         completion, _ => new PlainMessageBuilder<K, V>());
+            var logic = new SingleSourceStageLogic<K, V, ConsumeResult<K, V>>(shape, Settings, Subscription, inheritedAttributes, 
+                                                                              _ => new PlainMessageBuilder<K, V>());
+            return (logic, logic.Control);
         }
     }
 }

--- a/src/Akka.Streams.Kafka/Stages/Consumers/Concrete/SourceWithOffsetContextStage.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/Concrete/SourceWithOffsetContextStage.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using Akka.Streams.Kafka.Dsl;
+using Akka.Streams.Kafka.Helpers;
 using Akka.Streams.Kafka.Messages;
 using Akka.Streams.Kafka.Settings;
 using Akka.Streams.Kafka.Stages.Consumers.Abstract;
@@ -46,14 +47,14 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Concrete
         }
 
         /// <inheritdoc />
-        protected override GraphStageLogic Logic(
+        protected override (GraphStageLogic, IControl) Logic(
             SourceShape<(ConsumeResult<K, V>, ICommittableOffset)> shape,
-            TaskCompletionSource<NotUsed> completion,
             Attributes inheritedAttributes)
         {
-            return new SingleSourceStageLogic<K, V, (ConsumeResult<K, V>, ICommittableOffset)>(shape, Settings, Subscription, 
-                                                                                               inheritedAttributes, completion, 
-                                                                                               GetMessageBuilder);
+            var logic = new SingleSourceStageLogic<K, V, (ConsumeResult<K, V>, ICommittableOffset)>(shape, Settings, Subscription, 
+                                                                                                    inheritedAttributes, 
+                                                                                                    GetMessageBuilder);
+            return (logic, logic.Control);
         }
         
         private OffsetContextBuilder<K, V> GetMessageBuilder(BaseSingleSourceLogic<K, V, (ConsumeResult<K, V>, ICommittableOffset)> logic)


### PR DESCRIPTION
So far, all consumer stage's materialized value was `Task` - but actually it should be `IControl` object.

In addition to `IsShutdown` property, that returns task which finishes after stage is stopped, this object also has method for graceful stop of the source from outside. Which is very important, because kafka consuming stage will not stop by itself until downstream will be finished.

Tests are also updated, one of them uses new `Shutdown()` method to stop source instead of `probe.Cancel()` method that will finish downstream.