### PR TITLE
CommitWithMetadataPartitioned source

### DIFF
--- a/src/Akka.Streams.Kafka/Dsl/KafkaConsumer.cs
+++ b/src/Akka.Streams.Kafka/Dsl/KafkaConsumer.cs
@@ -132,5 +132,14 @@ namespace Akka.Streams.Kafka.Dsl
                return message.Record;
             });
         }
+
+        /// <summary>
+        /// The same as <see cref="PlainPartitionedSource{K,V}"/> but with offset commit with metadata support.
+        /// </summary>
+        public static Source<(TopicPartition, Source<CommittableMessage<K, V>, NotUsed>), IControl> CommitWithMetadataPartitionedSource<K, V>(
+            ConsumerSettings<K, V> settings, IAutoSubscription subscription, Func<ConsumeResult<K, V>, string> metadataFromRecord)
+        {
+            return Source.FromGraph(new CommittableSubSourceStage<K, V>(settings, subscription, metadataFromRecord));
+        }
     }
 }


### PR DESCRIPTION
One more source for issue #36. 

Very small PR, because is completely based on existing consuming stages (actually just uses one of the overloads of already tested consuming source stage). 