### PR TITLE
PlainPartitionedSource_should_work racy test fix

### DIFF
--- a/src/Akka.Streams.Kafka/Akka.Streams.Kafka.csproj
+++ b/src/Akka.Streams.Kafka/Akka.Streams.Kafka.csproj
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="Akka.Streams" Version="$(AkkaVersion)" />
-    <PackageReference Include="Confluent.Kafka" Version="1.2.2" />
+    <PackageReference Include="Confluent.Kafka" Version="1.3.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
After update to Confluent.Kafka 1.3.0 startup time for consumer increased to ~6 seconds for some reason. Maybe we shell check our docker image version, if it is outdated for this consumer version...

Anyway, one of the tests was very dependent on timings - so made it more robust.