### PR TITLE
added v1.0.2-beta2 release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,13 +1,7 @@
-#### 1.0.0 November 27 2019 ####
-**First beta release of Akka.Streams.Kafka**
+#### 1.0.0-beta2 February 18 2020 ####
+**Second beta release of Akka.Streams.Kafka**
 
-In this release, library was rewritten almost completely.
-Conceptually, the main part of this release is implementing all consuming and producing stages supported in Alpakka project: https://github.com/akka/alpakka.
-See https://github.com/akkadotnet/Akka.Streams.Kafka/issues/36 for full list of implemented stages (there are 11 consumer and 3 producer stages implemented).
+This release builds upon the work of the 1.0.0-beta1 released last year, but with some improvements and changes:
 
-Transactional stages are partially implemented, but waiting for issue https://github.com/akkadotnet/Akka.Streams.Kafka/issues/85 to be resolved 
-(which in turn is waiting for issue in Confluent driver to be closed).
-
-Among the others improvements, some critical issues were resolved, like
-- Get rid of internal buffering and scheduled pooling in Consumer stages (https://github.com/akkadotnet/Akka.Streams.Kafka/issues/35)
-- DrainControl class is implement, which allows to shutdown stages from outside (so does not require source to be finished to stop processing)
+- Updated to use Akka.NET v1.4.0-beta4;
+- [Bugfix: InvalidOperationException](https://github.com/akkadotnet/Akka.Streams.Kafka/issues/103)

--- a/src/common.props
+++ b/src/common.props
@@ -3,15 +3,10 @@
     <Copyright>Copyright © 2015-2019 .NET Foundation</Copyright>
     <Authors>Akka</Authors>
     <VersionPrefix>1.0.0</VersionPrefix>
-    <PackageReleaseNotes>First beta release of Akka.Streams.Kafka**
-In this release, library was rewritten almost completely.
-Conceptually, the main part of this release is implementing all consuming and producing stages supported in Alpakka project: https://github.com/akka/alpakka.
-See https://github.com/akkadotnet/Akka.Streams.Kafka/issues/36 for full list of implemented stages (there are 11 consumer and 3 producer stages implemented).
-Transactional stages are partially implemented, but waiting for issue https://github.com/akkadotnet/Akka.Streams.Kafka/issues/85 to be resolved
-(which in turn is waiting for issue in Confluent driver to be closed).
-Among the others improvements, some critical issues were resolved, like
-- Get rid of internal buffering and scheduled pooling in Consumer stages (https://github.com/akkadotnet/Akka.Streams.Kafka/issues/35)
-- DrainControl class is implement, which allows to shutdown stages from outside (so does not require source to be finished to stop processing)</PackageReleaseNotes>
+    <PackageReleaseNotes>Second beta release of Akka.Streams.Kafka**
+This release builds upon the work of the 1.0.0-beta1 released last year, but with some improvements and changes:
+- Updated to use Akka.NET v1.4.0-beta4;
+- [Bugfix: InvalidOperationException](https://github.com/akkadotnet/Akka.Streams.Kafka/issues/103)</PackageReleaseNotes>
     <PackageIconUrl>http://getakka.net/images/akkalogo.png</PackageIconUrl>
     <PackageProjectUrl>
       https://github.com/akkadotnet/Akka.Streams.Kafka


### PR DESCRIPTION
#### 1.0.0-beta2 February 18 2020 ####
**Second beta release of Akka.Streams.Kafka**

This release builds upon the work of the 1.0.0-beta1 released last year, but with some improvements and changes:

- Updated to use Akka.NET v1.4.0-beta4;
- [Bugfix: InvalidOperationException](https://github.com/akkadotnet/Akka.Streams.Kafka/issues/103)