### PR TITLE
added v1.0.0-RC1 release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,7 +1,4 @@
-#### 1.0.0-beta2 February 18 2020 ####
-**Second beta release of Akka.Streams.Kafka**
+#### 1.0.0-rc1 March 02 2020 ####
+**Stable release candidate of Akka.Streams.Kafka**
 
-This release builds upon the work of the 1.0.0-beta1 released last year, but with some improvements and changes:
-
-- Updated to use Akka.NET v1.4.0-beta4;
-- [Bugfix: InvalidOperationException](https://github.com/akkadotnet/Akka.Streams.Kafka/issues/103)
+Updated to use Akka.NET v1.4.1-rc1 and offers stable API access to Akka.Streams.Kafka.

--- a/src/Akka.Streams.Kafka/Akka.Streams.Kafka.csproj
+++ b/src/Akka.Streams.Kafka/Akka.Streams.Kafka.csproj
@@ -16,5 +16,16 @@
     <PackageReference Include="Akka.Streams" Version="$(AkkaVersion)" />
     <PackageReference Include="Confluent.Kafka" Version="1.3.0" />
   </ItemGroup>
-
+   <PropertyGroup>
+    <!-- Optional: Publish the repository URL in the built .nupkg (in the NuSpec <Repository> element) -->
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <!-- Optional: Embed source files that are not tracked by the source control manager in the PDB -->
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <!-- Optional: Build symbol package (.snupkg) to distribute the PDB containing Source Link -->
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
 </Project>

--- a/src/common.props
+++ b/src/common.props
@@ -3,10 +3,8 @@
     <Copyright>Copyright © 2015-2020 .NET Foundation</Copyright>
     <Authors>Akka</Authors>
     <VersionPrefix>1.0.0</VersionPrefix>
-    <PackageReleaseNotes>Second beta release of Akka.Streams.Kafka**
-This release builds upon the work of the 1.0.0-beta1 released last year, but with some improvements and changes:
-- Updated to use Akka.NET v1.4.0-beta4;
-- [Bugfix: InvalidOperationException](https://github.com/akkadotnet/Akka.Streams.Kafka/issues/103)</PackageReleaseNotes>
+    <PackageReleaseNotes>Stable release candidate of Akka.Streams.Kafka**
+Updated to use Akka.NET v1.4.1-rc1 and offers stable API access to Akka.Streams.Kafka.</PackageReleaseNotes>
     <PackageIconUrl>http://getakka.net/images/akkalogo.png</PackageIconUrl>
     <PackageProjectUrl>
       https://github.com/akkadotnet/Akka.Streams.Kafka


### PR DESCRIPTION
#### 1.0.0-rc1 March 02 2020 ####
**Stable release candidate of Akka.Streams.Kafka**

Updated to use Akka.NET v1.4.1-rc1 and offers stable API access to Akka.Streams.Kafka.