### PR TITLE
Fixes for batch committer flow and commit refreshing

### DIFF
--- a/src/Akka.Streams.Kafka.Tests/Integration/CommitterFlowIntegrationTests.cs
+++ b/src/Akka.Streams.Kafka.Tests/Integration/CommitterFlowIntegrationTests.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Akka.Configuration;
+using Akka.Streams.Dsl;
+using Akka.Streams.Kafka.Dsl;
+using Akka.Streams.Kafka.Messages;
+using Akka.Streams.Kafka.Settings;
+using Akka.Streams.TestKit;
+using Akka.Streams.Kafka.Helpers;
+using Confluent.Kafka;
+using Xunit;
+using Xunit.Abstractions;
+using Config = Hocon.Config;
+
+namespace Akka.Streams.Kafka.Tests.Integration
+{
+    public class CommitterFlowIntegrationTests : KafkaIntegrationTests
+    {
+        public CommitterFlowIntegrationTests(ITestOutputHelper output, KafkaFixture fixture) 
+            : base(nameof(CommitterFlowIntegrationTests), output, fixture)
+        {
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(5)]
+        public async Task CommitterFlow_commits_offsets_from_CommittableSource(int batchSize)
+        {
+            var topic1 = CreateTopic(1);
+            var topicPartition1 = new TopicPartition(topic1, 0);
+            var group1 = CreateGroup(1);
+
+            await GivenInitializedTopic(topicPartition1);
+
+            await Source
+                .From(Enumerable.Range(1, 100))
+                .Select(elem => new ProducerRecord<Null, string>(topicPartition1, elem.ToString()))
+                .RunWith(KafkaProducer.PlainSink(ProducerSettings), Materializer);
+
+            var consumerSettings = CreateConsumerSettings<string>(group1);
+            var committedElements = new ConcurrentQueue<string>();
+            var committerSettings = CommitterSettings.WithMaxBatch(batchSize);
+            
+            var (task, probe1) = KafkaConsumer.CommittableSource(consumerSettings, Subscriptions.Assignment(topicPartition1))
+                .WhereNot(c => c.Record.Value == InitialMsg)
+                .SelectAsync(10, elem =>
+                {
+                    committedElements.Enqueue(elem.Record.Value);
+                    return Task.FromResult(elem.CommitableOffset as ICommittable);
+                })
+                .Via(Committer.Flow(committerSettings))
+                .ToMaterialized(this.SinkProbe<Done>(), Keep.Both)
+                .Run(Materializer);
+
+            probe1.Request(25 / batchSize);
+
+            foreach (var _ in Enumerable.Range(1, 25 / batchSize))
+            {
+                probe1.ExpectNext(Done.Instance, TimeSpan.FromSeconds(10));
+            }
+                
+            probe1.Cancel();
+
+            AwaitCondition(() => task.IsShutdown.IsCompletedSuccessfully);
+
+            var probe2 = KafkaConsumer.PlainSource(consumerSettings, Subscriptions.Assignment(new TopicPartition(topic1, 0)))
+                .Select(_ => _.Value)
+                .RunWith(this.SinkProbe<string>(), Materializer);
+
+            probe2.Request(75);
+            foreach (var i in Enumerable.Range(committedElements.Count + 1, 75).Select(c => c.ToString()))
+                probe2.ExpectNext(i, TimeSpan.FromSeconds(10));
+
+            probe2.Cancel();
+        }
+    }
+}

--- a/src/Akka.Streams.Kafka/Helpers/CommitRefreshing.cs
+++ b/src/Akka.Streams.Kafka/Helpers/CommitRefreshing.cs
@@ -104,7 +104,7 @@ namespace Akka.Streams.Kafka.Helpers
                 _requestedOffsets = _requestedOffsets.SetItems(requestedOffsetsToAdd);
                 
                 var committedOffsetsToAdd = assignedOffsets
-                    .Where(offset => !_requestedOffsets.ContainsKey(offset.TopicPartition))
+                    .Where(offset => !_committedOffsets.ContainsKey(offset.TopicPartition))
                     .ToImmutableDictionary(offset => offset.TopicPartition, offset => offset.Offset);
                 _requestedOffsets = _committedOffsets.SetItems(committedOffsetsToAdd);
                 

--- a/src/Akka.Streams.Kafka/Helpers/CommitRefreshing.cs
+++ b/src/Akka.Streams.Kafka/Helpers/CommitRefreshing.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Globalization;
 using System.Linq;
+using System.Threading;
 using Akka.Streams.Kafka.Stages.Consumers.Actors;
 using Confluent.Kafka;
 
@@ -26,7 +27,7 @@ namespace Akka.Streams.Kafka.Helpers
     {
         public static ICommitRefreshing<K, V> Create<K, V>(TimeSpan commitRefreshInterval)
         {
-            if (commitRefreshInterval == TimeSpan.MaxValue)
+            if (commitRefreshInterval == Timeout.InfiniteTimeSpan)
                 return new NoOp<K, V>();
             else
                 return new Impl<K, V>(commitRefreshInterval);

--- a/src/Akka.Streams.Kafka/Messages/CommittableOffsetBatch.cs
+++ b/src/Akka.Streams.Kafka/Messages/CommittableOffsetBatch.cs
@@ -76,7 +76,6 @@ namespace Akka.Streams.Kafka.Messages
             {
                 case ICommittableOffset committableOffset:
                     return UpdateWithOffset(committableOffset);
-                    break;
                 case ICommittableOffsetBatch committableOffsetBatch:
                     return UpdateWithBatch(committableOffsetBatch);
                 default:
@@ -143,7 +142,7 @@ namespace Akka.Streams.Kafka.Messages
             }
             else
             {
-                Committers.SetItem(partitionOffset.GroupId, committer);
+                newCommitters = Committers.SetItem(partitionOffset.GroupId, committer);
             }
             
             return new CommittableOffsetBatch(newOffsets, newCommitters, BatchSize + 1);

--- a/src/Akka.Streams.Kafka/Settings/ConsumerSettings.cs
+++ b/src/Akka.Streams.Kafka/Settings/ConsumerSettings.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Threading;
 using Akka.Actor;
 using Akka.Streams.Kafka.Stages.Consumers.Exceptions;
 using Confluent.Kafka;
@@ -48,7 +49,7 @@ namespace Akka.Streams.Kafka.Settings
                 partitionHandlerWarning: config.GetTimeSpan("partition-handler-warning", TimeSpan.FromSeconds(5)),
                 commitTimeWarning: config.GetTimeSpan("commit-time-warning", TimeSpan.FromSeconds(1)),
                 commitTimeout: config.GetTimeSpan("commit-timeout", TimeSpan.FromSeconds(15)),
-                commitRefreshInterval: config.GetTimeSpan("commit-refresh-interval", TimeSpan.Zero, allowInfinite: true),
+                commitRefreshInterval: config.GetTimeSpan("commit-refresh-interval", Timeout.InfiniteTimeSpan, allowInfinite: true),
                 stopTimeout: config.GetTimeSpan("stop-timeout", TimeSpan.FromSeconds(30)),
                 positionTimeout: config.GetTimeSpan("position-timeout", TimeSpan.FromSeconds(5)),
                 waitClosePartition: config.GetTimeSpan("wait-close-partition", TimeSpan.FromSeconds(1)),
@@ -201,7 +202,7 @@ namespace Akka.Streams.Kafka.Settings
         /// </summary>
         public ConsumerSettings<TKey, TValue> WithCommitRefreshInterval(TimeSpan commitRefreshInterval)
         {
-            return Copy(commitRefreshInterval: commitRefreshInterval == TimeSpan.Zero ? TimeSpan.MaxValue : commitRefreshInterval);
+            return Copy(commitRefreshInterval: commitRefreshInterval == TimeSpan.Zero ? Timeout.InfiniteTimeSpan : commitRefreshInterval);
         }
         
         /// <summary>

--- a/src/Akka.Streams.Kafka/reference.conf
+++ b/src/Akka.Streams.Kafka/reference.conf
@@ -45,6 +45,11 @@ akka.kafka.consumer {
   # If commits take longer than this time a warning is logged
   commit-time-warning = 1s
 
+  # Not relevant for Kafka after version 2.1.0.
+  # If set to a finite duration, the consumer will re-send the last committed offsets periodically
+  # for all assigned partitions. See https://issues.apache.org/jira/browse/KAFKA-4682.
+  commit-refresh-interval = infinite
+
   buffer-size = 128
   
   # Fully qualified config path which holds the dispatcher configuration


### PR DESCRIPTION
First of all, thanks for putting this project out there! I just started exploring it recently and discovered some unexpected behavior when trying to use Committer.Flow and Committer.Sink for batch commits with CommittableSource. I tracked it down to a couple issues.

The first thing was a missing assignment in CommittableOffsetBatch, resulting in the initial batch not getting created correctly.

After fixing that I noticed offsets would continually reset back to the initial batch. I narrowed this down to the offset management in the commit refreshing code. I switched some sets to dictionaries (which matches the Scala implementation slightly more closely) to resolve the unbounded growth of offsets.

Additionally, it appears the default for commit refreshing should be disabled, but instead the refresh interval ended up be zero, so refreshes were occurring on every poll iteration. I updated that, added the missing config setting to reference.conf, and changed the "disabled" value to match what HOCON is using for infinite.

Also included a integration test which is basically a variation on one of the tests for CommittableSource.