### PR TITLE
Disabled auto commit Confluent consumer feature for tests

### DIFF
--- a/src/Akka.Streams.Kafka.Tests/KafkaIntegrationTests.cs
+++ b/src/Akka.Streams.Kafka.Tests/KafkaIntegrationTests.cs
@@ -66,6 +66,7 @@ namespace Akka.Streams.Kafka.Tests
                 .WithBootstrapServers(_fixture.KafkaServer)
                 .WithStopTimeout(TimeSpan.FromSeconds(1))
                 .WithProperty("auto.offset.reset", "earliest")
+                .WithProperty("enable.auto.commit", "false")
                 .WithGroupId(group);
         }
         

--- a/src/common.props
+++ b/src/common.props
@@ -16,7 +16,7 @@ Updated to use Akka.NET v1.4.1.</PackageReleaseNotes>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
   <PropertyGroup>
-    <AkkaVersion>1.4.1</AkkaVersion>
+    <AkkaVersion>1.4.4</AkkaVersion>
     <XunitVersion>2.4.1</XunitVersion>
     <NBenchVersion>1.2.2</NBenchVersion>
     <TestSdkVersion>16.6.0</TestSdkVersion>


### PR DESCRIPTION
This fixes tests failure that sometimes happen, like in https://github.com/akkadotnet/Akka.Streams.Kafka/pull/123