### PR TITLE
Upgrade to Akka.Streams.Kafka 1.5.2 and AutoCreateTopicsEnabled setting

### DIFF
--- a/src/Akka.Streams.Kafka.Tests/Integration/PlainPartitionedManualOffsetSourceIntegrationTests.cs
+++ b/src/Akka.Streams.Kafka.Tests/Integration/PlainPartitionedManualOffsetSourceIntegrationTests.cs
@@ -90,6 +90,9 @@ namespace Akka.Streams.Kafka.Tests.Integration
             var partitionsAssigned = false;
             var revoked = Option<IImmutableSet<TopicPartition>>.None;
             
+            // Create topic to allow consumer assignment
+            await ProduceStrings(topic, new []{ 0 }, ProducerSettings);
+            
             var source = KafkaConsumer.PlainPartitionedManualOffsetSource(consumerSettings, Subscriptions.Topics(topic),
                 assignedPartitions =>
                 {

--- a/src/Akka.Streams.Kafka.Tests/Integration/PlainPartitionedSourceIntegrationTests.cs
+++ b/src/Akka.Streams.Kafka.Tests/Integration/PlainPartitionedSourceIntegrationTests.cs
@@ -155,6 +155,8 @@ namespace Akka.Streams.Kafka.Tests.Integration
         {
             var topic = CreateTopic(1);
             var group = CreateGroup(1);
+            
+            await ProduceStrings(topic, new int[] { 0 }, ProducerSettings); // Produce "0" string
 
             var settings = CreateConsumerSettings<int>(group).WithValueDeserializer(Deserializers.Int32);
             

--- a/src/Akka.Streams.Kafka/Akka.Streams.Kafka.csproj
+++ b/src/Akka.Streams.Kafka/Akka.Streams.Kafka.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Akka.Streams" Version="$(AkkaVersion)" />
-    <PackageReference Include="Confluent.Kafka" Version="1.4.3" />
+    <PackageReference Include="Confluent.Kafka" Version="1.5.2" />
   </ItemGroup>
    <PropertyGroup>
     <!-- Optional: Publish the repository URL in the built .nupkg (in the NuSpec <Repository> element) -->

--- a/src/Akka.Streams.Kafka/Settings/ConsumerSettings.cs
+++ b/src/Akka.Streams.Kafka/Settings/ConsumerSettings.cs
@@ -55,6 +55,7 @@ namespace Akka.Streams.Kafka.Settings
                 bufferSize: config.GetInt("buffer-size", 50),
                 drainingCheckInterval: config.GetTimeSpan("eos-draining-check-interval", TimeSpan.FromMilliseconds(30)),
                 dispatcherId: config.GetString("use-dispatcher", "akka.kafka.default-dispatcher"),
+                autoCreateTopicsEnabled: config.GetBoolean("allow.auto.create.topics", true),
                 properties: ImmutableDictionary<string, string>.Empty);
         }
 
@@ -119,6 +120,16 @@ namespace Akka.Streams.Kafka.Settings
         /// </summary>
         public string DispatcherId { get; }
         /// <summary>
+        /// Allow automatic topic creation on the broker when subscribing to or assigning a topic.
+        /// </summary>
+        /// <remarks>
+        /// See more here: https://kafka.apache.org/documentation/#allow.auto.create.topics
+        /// Additionally, due to https://github.com/confluentinc/confluent-kafka-dotnet/issues/1366 ,
+        /// when set to `true` and topic is not created by Confluent driver, consuming error will be ignored
+        /// (like if no message to consume)
+        /// </remarks>
+        public bool AutoCreateTopicsEnabled { get; }
+        /// <summary>
         /// Configuration properties
         /// </summary>
         public IImmutableDictionary<string, string> Properties { get; }
@@ -126,7 +137,7 @@ namespace Akka.Streams.Kafka.Settings
         public ConsumerSettings(IDeserializer<TKey> keyDeserializer, IDeserializer<TValue> valueDeserializer, TimeSpan pollInterval, 
                                 TimeSpan pollTimeout, TimeSpan commitTimeout, TimeSpan commitRefreshInterval, TimeSpan stopTimeout, 
                                 TimeSpan positionTimeout, TimeSpan commitTimeWarning, TimeSpan partitionHandlerWarning,
-                                TimeSpan waitClosePartition, TimeSpan drainingCheckInterval,
+                                TimeSpan waitClosePartition, TimeSpan drainingCheckInterval, bool autoCreateTopicsEnabled,
                                 int bufferSize, string dispatcherId, IImmutableDictionary<string, string> properties)
         {
             KeyDeserializer = keyDeserializer;
@@ -144,6 +155,7 @@ namespace Akka.Streams.Kafka.Settings
             Properties = properties;
             WaitClosePartition = waitClosePartition;
             DrainingCheckInterval = drainingCheckInterval;
+            AutoCreateTopicsEnabled = autoCreateTopicsEnabled;
         }
 
         /// <summary>
@@ -194,6 +206,13 @@ namespace Akka.Streams.Kafka.Settings
         /// Time to wait for pending requests when a partition is closed.
         /// </summary>
         public ConsumerSettings<TKey, TValue> WithWaitClosePartition(TimeSpan waitClosePartition) => Copy(waitClosePartition: waitClosePartition);
+        /// <summary>
+        /// Allows topic auto-creation when constumer is subscribing or assigning to the topic.
+        /// </summary>
+        /// <remarks>
+        /// When set, and still getting error from broker, consumer will assume that no message was produced yet
+        /// </remarks>
+        public ConsumerSettings<TKey, TValue> WithAutoCreateTopicsEnabled(bool autoCreateTopicsEnabled) => Copy(autoCreateTopicsEnabled: autoCreateTopicsEnabled);
         
         /// <summary>
         /// If set to a finite duration, the consumer will re-send the last committed offsets periodically for all assigned partitions.
@@ -254,6 +273,7 @@ namespace Akka.Streams.Kafka.Settings
             TimeSpan? stopTimeout = null,
             TimeSpan? positionTimeout = null,
             TimeSpan? waitClosePartition = null,
+            bool? autoCreateTopicsEnabled = null,
             int? bufferSize = null,
             string dispatcherId = null,
             IImmutableDictionary<string, string> properties = null) =>
@@ -272,6 +292,7 @@ namespace Akka.Streams.Kafka.Settings
                 bufferSize: bufferSize ?? this.BufferSize,
                 drainingCheckInterval: drainingCheckInterval ?? this.DrainingCheckInterval,
                 dispatcherId: dispatcherId ?? this.DispatcherId,
+                autoCreateTopicsEnabled: autoCreateTopicsEnabled ?? this.AutoCreateTopicsEnabled,
                 properties: properties ?? this.Properties);
 
         /// <summary>

--- a/src/Akka.Streams.Kafka/Stages/Consumers/Actors/KafkaConsumerActor.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/Actors/KafkaConsumerActor.cs
@@ -318,9 +318,14 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
                     var pauseThese = currentAssignment.Except(resumeThese).ToList();
                     PausePartitions(pauseThese);
                     ResumePartitions(resumeThese);
-                    
+
                     ProcessResult(partitionsToFetch, _consumer.Consume(_settings.PollTimeout));
                 }
+            }
+            // Workaroud for https://github.com/confluentinc/confluent-kafka-dotnet/issues/1366
+            catch (ConsumeException ex) when (ex.Message.Contains("Broker: Unknown topic or partition") && _settings.AutoCreateTopicsEnabled)
+            {
+                // Trying to consume from not existing topics/partitions - assume that there are not messages to consume
             }
             catch (ConsumeException ex)
             {

--- a/src/Akka.Streams.Kafka/reference.conf
+++ b/src/Akka.Streams.Kafka/reference.conf
@@ -78,6 +78,9 @@ akka.kafka.consumer {
   # Issue warnings when a call to a partition assignment handler method takes
   # longer than this.
   partition-handler-warning = 5s
+
+  # Allow automatic topic creation on the broker when subscribing to or assigning a topic
+  allow.auto.create.topics = true
 }
 
 # The dispatcher that will be used by default by consumer and


### PR DESCRIPTION
Continue work on https://github.com/akkadotnet/Akka.Streams.Kafka/pull/156

Due to breaking change of 1.5.0 release of librdkafka library, there was an issue discussed here: https://github.com/confluentinc/confluent-kafka-dotnet/issues/1366 - topics are not automatically created when consumer is subscribing to them anymore. 

We are handling this breaking change for our users on our side. This is still possible to get back to default behavior by adding `allow.auto.create.topics = false` setting for kafka consumer. 