### PR TITLE
Added release notes for Akka.Streams.Kafka 1.1.1

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,2 +1,6 @@
-#### 1.1.0 August 24 2020 ####
-_Placeholder for nightlies_
+#### 1.1.1 November 6 2020 ####
+
+* Upgraded to [Akka.NET v1.4.11](https://github.com/akkadotnet/akka.net/releases/tag/1.4.11)
+* [Upgrade to Confluent.Kafka 1.5.2 and AutoCreateTopicsEnabled setting](https://github.com/akkadotnet/Akka.Streams.Kafka/pull/157)
+* [Resolved: Broker: Unknown topic or partition after upgrading to kafka 1.5.0+](https://github.com/akkadotnet/Akka.Streams.Kafka/issues/158)
+* [Added support for custom IPartitionEventHandler instances in subscriptions](https://github.com/akkadotnet/Akka.Streams.Kafka/issues/149)


### PR DESCRIPTION
#### 1.1.1 November 6 2020 ####

* Upgraded to [Akka.NET v1.4.11](https://github.com/akkadotnet/akka.net/releases/tag/1.4.11)
* [Upgrade to Confluent.Kafka 1.5.2 and AutoCreateTopicsEnabled setting](https://github.com/akkadotnet/Akka.Streams.Kafka/pull/157)
* [Resolved: Broker: Unknown topic or partition after upgrading to kafka 1.5.0+](https://github.com/akkadotnet/Akka.Streams.Kafka/issues/158)
* [Added support for custom IPartitionEventHandler instances in subscriptions](https://github.com/akkadotnet/Akka.Streams.Kafka/issues/149)