### PR TITLE
added v1.1.1 release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,5 @@
-#### 1.1.0 November 6 2020 ####
+#### 1.1.1 December 16 2020 ####
 
-* Upgraded to [Akka.NET v1.4.11](https://github.com/akkadotnet/akka.net/releases/tag/1.4.11)
-* [Upgrade to Confluent.Kafka 1.5.2 and AutoCreateTopicsEnabled setting](https://github.com/akkadotnet/Akka.Streams.Kafka/pull/157)
-* [Resolved: Broker: Unknown topic or partition after upgrading to kafka 1.5.0+](https://github.com/akkadotnet/Akka.Streams.Kafka/issues/158)
-* [Added support for custom IPartitionEventHandler instances in subscriptions](https://github.com/akkadotnet/Akka.Streams.Kafka/issues/149)
+* Upgraded to [Akka.NET v1.4.13](https://github.com/akkadotnet/akka.net/releases/tag/1.4.13)
+* Upgrade to Confluent.Kafka 1.5.3
+* [Make Akka.Streams.Kafka client compatible with Azure Event Hub Kafka API](https://github.com/akkadotnet/Akka.Streams.Kafka/pull/167)

--- a/src/common.props
+++ b/src/common.props
@@ -2,8 +2,10 @@
   <PropertyGroup>
     <Copyright>Copyright © 2015-2020 .NET Foundation</Copyright>
     <Authors>Akka</Authors>
-    <VersionPrefix>1.1.0</VersionPrefix>
-    <PackageReleaseNotes>_Placeholder for nightlies_</PackageReleaseNotes>
+    <VersionPrefix>1.1.1</VersionPrefix>
+    <PackageReleaseNotes>Upgraded to [Akka.NET v1.4.13](https://github.com/akkadotnet/akka.net/releases/tag/1.4.13)
+Upgrade to Confluent.Kafka 1.5.3
+[Make Akka.Streams.Kafka client compatible with Azure Event Hub Kafka API](https://github.com/akkadotnet/Akka.Streams.Kafka/pull/167)</PackageReleaseNotes>
     <PackageIconUrl>http://getakka.net/images/akkalogo.png</PackageIconUrl>
     <PackageProjectUrl>
       https://github.com/akkadotnet/Akka.Streams.Kafka


### PR DESCRIPTION
#### 1.1.1 December 16 2020 ####

* Upgraded to [Akka.NET v1.4.13](https://github.com/akkadotnet/akka.net/releases/tag/1.4.13)
* Upgrade to Confluent.Kafka 1.5.3
* [Make Akka.Streams.Kafka client compatible with Azure Event Hub Kafka API](https://github.com/akkadotnet/Akka.Streams.Kafka/pull/167)