### PR TITLE
log consumer errors more explicitly

### DIFF
--- a/src/Akka.Streams.Kafka/Stages/Consumers/Actors/KafkaConsumerActor.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/Actors/KafkaConsumerActor.cs
@@ -589,7 +589,7 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
         private void ProcessConsumingError(ConsumeException ex)
         {
             var error = ex.Error;
-            _log.Error(error.Reason);
+            _log.Error(ex, $"ConsumerError: Code={error.Code}, Reason={error.Reason}, IsError={error.IsError}, IsFatal={error.IsFatal}");
 
             if (!KafkaExtensions.IsBrokerErrorRetriable(error) && !KafkaExtensions.IsLocalErrorRetriable(error))
             {


### PR DESCRIPTION
The Confluent .NET Kafka library logs a lot of things as exceptions that are not errors: https://github.com/confluentinc/confluent-kafka-dotnet/issues/310 - the way we handle these in our Akka.Streams.Kafka consumer stages seems erroneous at best. We need some better data capture around these issues when they happen so users can file bug reports and properly diagnose the underlying problems.