### PR TITLE
Fix Kafka polling method

### DIFF
--- a/src/Akka.Streams.Kafka.Tests/BugFix240SupervisionStrategy.cs
+++ b/src/Akka.Streams.Kafka.Tests/BugFix240SupervisionStrategy.cs
@@ -178,7 +178,7 @@ namespace Akka.Streams.Kafka.Tests
             probe.ExpectNoMsg(TimeSpan.FromSeconds(2));
             probe.Cancel();
 
-            pulled.Should().BeEquivalentTo(new[] {1, 2, 3, 4, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10});
+            pulled.Should().BeEquivalentTo(new[] {1, 2, 3, 4, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, opt => opt.WithStrictOrdering());
             
             // Decider should be called twice, because deciders are called in BaseSingleSourceLogic and KafkaConsumerActor 
             callCount.Should().Be(2);

--- a/src/Akka.Streams.Kafka.Tests/Integration/PlainPartitionedSourceIntegrationTests.cs
+++ b/src/Akka.Streams.Kafka.Tests/Integration/PlainPartitionedSourceIntegrationTests.cs
@@ -37,8 +37,9 @@ namespace Akka.Streams.Kafka.Tests.Integration
             var totalMessages = 100;
             var receivedMessages = new AtomicCounter(0); 
 
-            var consumerSettings = CreateConsumerSettings<string>(group);
+            await ProduceStrings(topic, Enumerable.Range(1, totalMessages), ProducerSettings);
 
+            var consumerSettings = CreateConsumerSettings<string>(group);
             var control = KafkaConsumer.PlainPartitionedSource(consumerSettings, Subscriptions.Topics(topic))
                 .GroupBy(3, tuple => tuple.Item1)
                 .SelectAsync(8, async tuple =>
@@ -64,8 +65,6 @@ namespace Akka.Streams.Kafka.Tests.Integration
                 .MapMaterializedValue(tuple => DrainingControl<long>.Create(tuple.Item1, tuple.Item2))
                 .Run(Materializer);
             
-            await ProduceStrings(topic, Enumerable.Range(1, totalMessages), ProducerSettings);
-
             for (var i = 0; i < totalMessages; ++i)
                 await AwaitConditionAsync(() => receivedMessages.Current > i, TimeSpan.FromSeconds(10));
 
@@ -83,8 +82,9 @@ namespace Akka.Streams.Kafka.Tests.Integration
             var group = CreateGroup(1);
             var totalMessages = 100;
 
-            var consumerSettings = CreateConsumerSettings<string>(group);
+            await ProduceStrings(topic, Enumerable.Range(1, totalMessages), ProducerSettings);
 
+            var consumerSettings = CreateConsumerSettings<string>(group);
             var control = KafkaConsumer.PlainPartitionedSource(consumerSettings, Subscriptions.Topics(topic))
                 .SelectAsync(6, async tuple =>
                 {
@@ -102,8 +102,6 @@ namespace Akka.Streams.Kafka.Tests.Integration
                 .MapMaterializedValue(tuple => DrainingControl<bool>.Create(tuple.Item1, tuple.Item2))
                 .Run(Materializer);
             
-            await ProduceStrings(topic, Enumerable.Range(1, totalMessages), ProducerSettings);
-
             // Give it some time to consume all messages
             await Task.Delay(5000);
 

--- a/src/Akka.Streams.Kafka/Stages/Consumers/Abstract/KafkaSourceStage.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/Abstract/KafkaSourceStage.cs
@@ -38,10 +38,12 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
         {
             StageName = stageName;
             Shape = new SourceShape<TMessage>(Out);
+            InitialAttributes = Attributes.CreateName(StageName)
+                .And(ActorAttributes.CreateSupervisionStrategy(new DefaultConsumerDecider(true).Decide));
         }
 
         /// <inheritdoc />
-        protected override Attributes InitialAttributes => Attributes.CreateName(StageName);
+        protected override Attributes InitialAttributes { get; }
         
         /// <summary>
         /// Provides actual stage logic

--- a/src/Akka.Streams.Kafka/Stages/Consumers/Abstract/SingleSourceStageLogic.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/Abstract/SingleSourceStageLogic.cs
@@ -77,7 +77,7 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
                 throw new ArgumentException($"Expected {typeof(ActorMaterializer)} but got {Materializer.GetType()}");
             
             var extendedActorSystem = actorMaterializer.System.AsInstanceOf<ExtendedActorSystem>();
-            var actor = extendedActorSystem.SystemActorOf(KafkaConsumerActorMetadata.GetProps(SourceActor.Ref, _settings, eventHandler, statisticsHandler),
+            var actor = extendedActorSystem.SystemActorOf(KafkaConsumerActorMetadata.GetProps(SourceActor.Ref, _settings, Decider, eventHandler, statisticsHandler),
                                                           $"kafka-consumer-{KafkaConsumerActorMetadata.NextNumber()}");
             return actor;
         }

--- a/src/Akka.Streams.Kafka/Stages/Consumers/Abstract/SubSourceLogic.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/Abstract/SubSourceLogic.cs
@@ -151,8 +151,9 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
                 : new StatisticsHandlers.Empty();
 
             var extendedActorSystem = actorMaterializer.System.AsInstanceOf<ExtendedActorSystem>();
-            ConsumerActor = extendedActorSystem.SystemActorOf(KafkaConsumerActorMetadata.GetProps(SourceActor.Ref, _settings, eventHandler, statisticsHandler),
-                                                              $"kafka-consumer-{_actorNumber}");
+            ConsumerActor = extendedActorSystem.SystemActorOf(
+                KafkaConsumerActorMetadata.GetProps(SourceActor.Ref, _settings, _decider, eventHandler, statisticsHandler), 
+                $"kafka-consumer-{_actorNumber}");
 
             SourceActor.Watch(ConsumerActor);
 

--- a/src/Akka.Streams.Kafka/Stages/Consumers/Actors/KafkaConsumerActor.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/Actors/KafkaConsumerActor.cs
@@ -15,6 +15,8 @@ using Akka.Util;
 using Akka.Util.Internal;
 using Confluent.Kafka;
 using Newtonsoft.Json;
+using Decider = Akka.Streams.Supervision.Decider;
+using Directive = Akka.Streams.Supervision.Directive;
 
 namespace Akka.Streams.Kafka.Stages.Consumers.Actors
 {
@@ -75,6 +77,7 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
         private bool _stopInProgress = false;
         private bool _delayedPoolInFlight = false;
         private IImmutableSet<TopicPartition> _resumedPartitions = ImmutableHashSet<TopicPartition>.Empty;
+        private readonly Decider _decider;
 
         /// <summary>
         /// While `true`, committing is delayed.
@@ -96,11 +99,13 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
         /// <param name="owner">Owner actor to send critical failures to</param>
         /// <param name="settings">Consumer settings</param>
         /// <param name="statisticsHandler">Statistics handler</param>
+        /// <param name="decider"></param>
         /// <param name="partitionEventHandler">Partion events handler</param>
-        public KafkaConsumerActor(IActorRef owner, ConsumerSettings<K, V> settings, IPartitionEventHandler partitionEventHandler, IStatisticsHandler statisticsHandler)
+        public KafkaConsumerActor(IActorRef owner, ConsumerSettings<K, V> settings, Decider decider, IPartitionEventHandler partitionEventHandler, IStatisticsHandler statisticsHandler)
         {
             _owner = owner;
             _settings = settings;
+            _decider = decider;
             _statisticsHandler = statisticsHandler;
             _partitionEventHandler = partitionEventHandler;
             
@@ -290,6 +295,10 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
                     PartitionsRevokedHandler(evt.Partitions);
                     return true;
                 
+                case Status.Failure fail:
+                    ProcessExceptions(fail.Cause);
+                    return true;
+                
                 default:
                     return false;
             }
@@ -323,14 +332,7 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
 
                 var localSelf = Self;
                 _consumer = _settings.CreateKafkaConsumer(
-                    consumeErrorHandler: (c, e) =>
-                    {
-                        var exception = new KafkaException(e);
-                        ProcessError(exception);
-                        _pollCancellation?.Cancel();
-                        _log.Error(exception, "Exception when polling from consumer, stopping actor: {0}", exception.ToString());
-                        Context.Stop(Self);
-                    },
+                    consumeErrorHandler: (c, e) => localSelf.Tell(new Status.Failure(new KafkaException(e))),
                     partitionAssignedHandler: (c, tp) => localSelf.Tell(new PartitionAssigned(tp.ToImmutableHashSet())),
                     partitionRevokedHandler: (c, tp) => localSelf.Tell(new PartitionRevoked(tp.ToImmutableHashSet())),
                     statisticHandler: (c, json) => _statisticsHandler.OnStatistics(c, json));
@@ -475,67 +477,57 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
             var currentAssignment = _consumer.Assignment;
             var initialRebalanceInProcess = _rebalanceInProgress;
 
-            try
+            if (_requests.IsEmpty())
             {
-                if (_requests.IsEmpty())
+                if(_log.IsDebugEnabled)
+                    _log.Debug("Requests are empty - attempting to consume.");
+                PausePartitions(currentAssignment);
+                try
                 {
-                    if(_log.IsDebugEnabled)
-                        _log.Debug("Requests are empty - attempting to consume.");
-                    PausePartitions(currentAssignment);
                     var consumed = _consumer.Consume(0);
                     if (consumed != null)
                         throw new IllegalActorStateException("Consumed message should be null");
                 }
-                else
+                catch (Exception e)
                 {
-                    // Seek has to be done here because they can somehow fail.
-                    // Would need to see if we can move this somewhere else
-                    // because a seek can take up to 200ms to complete
-                    foreach (var tpo in _seekedOffset.Select(kvp => kvp.Value))
-                    {
-                        try
-                        {
-                            if(_log.IsDebugEnabled)
-                                _log.Debug("Seeking offset {0} in partition {1} for topic {2}", tpo.Offset, tpo.Partition, tpo.Topic);
-                            _consumer.Seek(tpo);
-                        }
-                        catch (Exception ex)
-                        {
-                            _log.Error(ex, $"{tpo.TopicPartition} Failed to seek to {tpo.Offset}: {ex}");
-                            throw;
-                        }
-                    }
-                    
-                    // resume partitions to fetch
-                    IImmutableSet<TopicPartition> partitionsToFetch = _requests.Values.SelectMany(v => v.Topics).ToImmutableHashSet();
-                    var resumeThese = currentAssignment.Where(partitionsToFetch.Contains).ToList();
-                    var pauseThese = currentAssignment.Except(resumeThese).ToList();
-                    PausePartitions(pauseThese);
-                    ResumePartitions(resumeThese);
-
-                    using (var cts = new CancellationTokenSource(_settings.PollTimeout))
-                    {
-                        ProcessResult(partitionsToFetch, PollKafka(cts.Token));
-                    }
+                    ProcessExceptions(e);
                 }
             }
-            // Workaroud for https://github.com/confluentinc/confluent-kafka-dotnet/issues/1366
-            catch (ConsumeException ex) when (ex.Message.Contains("Broker: Unknown topic or partition") && _settings.AutoCreateTopicsEnabled)
+            else
             {
-                // Trying to consume from not existing topics/partitions - assume that there are not messages to consume
+                // Seek has to be done here because they can somehow fail.
+                // Would need to see if we can move this somewhere else
+                // because a seek can take up to 200ms to complete
+                foreach (var tpo in _seekedOffset.Select(kvp => kvp.Value))
+                {
+                    try
+                    {
+                        if(_log.IsDebugEnabled)
+                            _log.Debug("Seeking offset {0} in partition {1} for topic {2}", tpo.Offset, tpo.Partition, tpo.Topic);
+                        _consumer.Seek(tpo);
+                    }
+                    catch (Exception ex)
+                    {
+                        _log.Error(ex, $"{tpo.TopicPartition} Failed to seek to {tpo.Offset}: {ex}");
+                        throw;
+                    }
+                }
+                
+                // resume partitions to fetch
+                IImmutableSet<TopicPartition> partitionsToFetch = _requests.Values.SelectMany(v => v.Topics).ToImmutableHashSet();
+                var resumeThese = currentAssignment.Where(partitionsToFetch.Contains).ToList();
+                var pauseThese = currentAssignment.Except(resumeThese).ToList();
+                PausePartitions(pauseThese);
+                ResumePartitions(resumeThese);
+
+                using (var cts = new CancellationTokenSource(_settings.PollTimeout))
+                {
+                    var (polled, exception) = PollKafka(cts.Token);
+                    ProcessResult(partitionsToFetch, polled);
+                    ProcessExceptions(exception);
+                }
             }
-            catch (ConsumeException ex) when (ex.Error.IsSerializationError())
-            {
-                ProcessError(ex);
-            }
-            catch (Exception ex)
-            {
-                ProcessError(ex);
-                _pollCancellation?.Cancel();
-                _log.Error(ex, "Exception when polling from consumer, stopping actor: {0}", ex.ToString());
-                Context.Stop(Self);
-            }
-             
+            
             CheckRebalanceState(initialRebalanceInProcess);
 
             if (_stopInProgress)
@@ -545,22 +537,45 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
             }
         }
 
-        private List<ConsumeResult<K, V>> PollKafka(CancellationToken token)
+        private void ProcessExceptions(Exception exception)
+        {
+            if (exception == null)
+                return;
+
+            var directive = _decider(exception);
+            ProcessError(exception);
+            if (directive == Directive.Resume)
+                return;
+            
+            _pollCancellation?.Cancel();
+            if(directive == Directive.Stop && _log.IsErrorEnabled)
+                _log.Error(exception, "Exception when polling from consumer, stopping actor: {0}", exception.Message);
+            Context.Stop(Self);
+        }
+
+        private (List<ConsumeResult<K, V>>, Exception) PollKafka(CancellationToken token)
         {
             ConsumeResult<K, V> consumed = null;
             var i = 10; // 10 poll attempts
             var timeout = Math.Max((int) _pollTimeout.TotalMilliseconds / i, 1);
-            var pooled = new List<ConsumeResult<K, V>>();
+            var polled = new List<ConsumeResult<K, V>>();
             do
             {
-                // this would return immediately if there are messages waiting inside the client queue buffer
-                consumed = _consumer.Consume(timeout);
+                try
+                {
+                    // this would return immediately if there are messages waiting inside the client queue buffer
+                    consumed = _consumer.Consume(timeout);
+                }
+                catch (Exception e)
+                {
+                    return (polled, e);
+                }
                 if (consumed != null)
-                    pooled.Add(consumed);
+                    polled.Add(consumed);
                 i--;
-            } while (i > 0 && !token.IsCancellationRequested);
+            } while (i > 0 && consumed != null && !token.IsCancellationRequested);
 
-            return pooled;
+            return (polled, null);
         }
 
         private void ProcessResult(IImmutableSet<TopicPartition> partitionsToFetch, List<ConsumeResult<K,V>> rawResult)

--- a/src/Akka.Streams.Kafka/Stages/Consumers/Actors/KafkaConsumerActorMetadata.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/Actors/KafkaConsumerActorMetadata.cs
@@ -5,6 +5,7 @@ using Akka.Annotations;
 using Akka.Streams.Kafka.Helpers;
 using Akka.Streams.Kafka.Settings;
 using Confluent.Kafka;
+using Decider = Akka.Streams.Supervision.Decider;
 
 namespace Akka.Streams.Kafka.Stages.Consumers.Actors
 {
@@ -25,20 +26,20 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
         /// <summary>
         /// Gets actor props
         /// </summary>
-        public static Props GetProps<K, V>(ConsumerSettings<K, V> settings) =>
-            Props.Create(() => new KafkaConsumerActor<K, V>(ActorRefs.Nobody, settings, new PartitionEventHandlers.Empty(), new StatisticsHandlers.Empty())).WithDispatcher(settings.DispatcherId);
+        public static Props GetProps<K, V>(ConsumerSettings<K, V> settings, Decider decider) =>
+            Props.Create(() => new KafkaConsumerActor<K, V>(ActorRefs.Nobody, settings, decider, new PartitionEventHandlers.Empty(), new StatisticsHandlers.Empty())).WithDispatcher(settings.DispatcherId);
         
         /// <summary>
         /// Gets actor props
         /// </summary>
-        internal static Props GetProps<K, V>(ConsumerSettings<K, V> settings, IPartitionEventHandler handler, IStatisticsHandler statisticsHandler) =>
-            Props.Create(() => new KafkaConsumerActor<K, V>(ActorRefs.Nobody, settings, handler, statisticsHandler)).WithDispatcher(settings.DispatcherId);
+        internal static Props GetProps<K, V>(ConsumerSettings<K, V> settings, Decider decider, IPartitionEventHandler handler, IStatisticsHandler statisticsHandler) =>
+            Props.Create(() => new KafkaConsumerActor<K, V>(ActorRefs.Nobody, settings, decider, handler, statisticsHandler)).WithDispatcher(settings.DispatcherId);
         
         /// <summary>
         /// Gets actor props
         /// </summary>
-        internal static Props GetProps<K, V>(IActorRef owner, ConsumerSettings<K, V> settings, IPartitionEventHandler handler, IStatisticsHandler statisticsHandler) =>
-            Props.Create(() => new KafkaConsumerActor<K, V>(owner, settings, handler, statisticsHandler)).WithDispatcher(settings.DispatcherId);
+        internal static Props GetProps<K, V>(IActorRef owner, ConsumerSettings<K, V> settings, Decider decider, IPartitionEventHandler handler, IStatisticsHandler statisticsHandler) =>
+            Props.Create(() => new KafkaConsumerActor<K, V>(owner, settings, decider, handler, statisticsHandler)).WithDispatcher(settings.DispatcherId);
 
 
         /// <summary>


### PR DESCRIPTION
On previous polling implementation, when an exception happened during a poll, all of the messages consumed before the exception was thrown were discarded. The last offset/message pushed into the stream can be different, depending on how fast the broker and client exchanges messages and when the polling timer ran.